### PR TITLE
component: alert

### DIFF
--- a/app/components/dsfr_component/alert_component.rb
+++ b/app/components/dsfr_component/alert_component.rb
@@ -1,22 +1,79 @@
 class DsfrComponent::AlertComponent < DsfrComponent::Base
-  attr_reader :title
+  TYPES = %i[error success info warning].freeze
+  SIZES = %i[sm md].freeze
 
-  def initialize(title:, classes: [], html_attributes: {})
+  def initialize(type:, title: nil, size: :md, close_button: false, classes: [], html_attributes: {})
     @title = title
+    @type = type
+    @size = size
+    @close_button = close_button
 
     super(classes: classes, html_attributes: html_attributes)
   end
 
   def call
     tag.div(**html_attributes) do
-      tag.h3(class: "fr-alert__title") { title }
-      tag.p { content }
+      safe_join([title_tag, content_tag, close_button_tag])
     end
   end
 
 private
 
+  attr_reader :title, :type, :size, :close_button
+
   def default_attributes
-    { class: %w(fr-alert) }
+    { class: %w(fr-alert) + [type_class, size_class].compact }
+  end
+
+  def title_tag
+    tag.h3(class: "fr-alert__title") { title }
+  end
+
+  def content_tag
+    return nil if content.blank?
+
+    tag.p { content }
+  end
+
+  def close_button_tag
+    return nil unless close_button
+
+    tag.button(
+      class: "fr-btn--close fr-btn",
+      title: "Masquer le message",
+      onclick: "const alert = this.parentNode; alert.parentNode.removeChild(alert)"
+    ) do
+      "Masquer le message"
+    end
+  end
+
+  def type_class
+    fail(ArgumentError, type_error_message) unless valid_type?
+
+    "fr-alert--#{type}"
+  end
+
+  def valid_type?
+    type.present? && type.in?(TYPES)
+  end
+
+  def type_error_message
+    "invalid alert type #{type}, supported types are #{TYPES.to_sentence}"
+  end
+
+  def size_class
+    return nil if size == :md
+
+    fail(ArgumentError, size_error_message) unless valid_size?
+
+    "fr-alert--#{size}"
+  end
+
+  def valid_size?
+    size.in?(SIZES)
+  end
+
+  def size_error_message
+    "invalid alert size #{size}, supported sizes are #{SIZES.to_sentence}"
   end
 end

--- a/app/components/dsfr_component/alert_component.rb
+++ b/app/components/dsfr_component/alert_component.rb
@@ -13,7 +13,7 @@ class DsfrComponent::AlertComponent < DsfrComponent::Base
     @size = size
     @close_button = close_button
 
-    super(classes:, html_attributes:)
+    super(classes: classes, html_attributes: html_attributes)
   end
 
   def call

--- a/app/components/dsfr_component/alert_component.rb
+++ b/app/components/dsfr_component/alert_component.rb
@@ -2,13 +2,17 @@ class DsfrComponent::AlertComponent < DsfrComponent::Base
   TYPES = %i[error success info warning].freeze
   SIZES = %i[sm md].freeze
 
+  # @param type [Symbol] alert type (and matching color) `:success`, `:info ou `:error`
+  # @param title [String] alert title
+  # @param size [Symbol] alert size : `:md` (default) or `:sm`
+  # @param close_button [Boolean] display a close button to remove the alert
   def initialize(type:, title: nil, size: :md, close_button: false, classes: [], html_attributes: {})
     @title = title
     @type = type
     @size = size
     @close_button = close_button
 
-    super(classes: classes, html_attributes: html_attributes)
+    super(classes:, html_attributes:)
   end
 
   def call
@@ -54,7 +58,7 @@ private
   end
 
   def valid_type?
-    type.present? && type.in?(TYPES)
+    type.in?(TYPES)
   end
 
   def type_error_message

--- a/app/components/dsfr_component/alert_component.rb
+++ b/app/components/dsfr_component/alert_component.rb
@@ -2,10 +2,11 @@ class DsfrComponent::AlertComponent < DsfrComponent::Base
   TYPES = %i[error success info warning].freeze
   SIZES = %i[sm md].freeze
 
-  # @param type [Symbol] alert type (and matching color) `:success`, `:info ou `:error`
-  # @param title [String] alert title
+  # @param type [Symbol] alert type (and matching color) `:success`, `:info`, `:warning` ou `:error`
+  # @param title [String] alert title. cannot be set in size `:sm`
   # @param size [Symbol] alert size : `:md` (default) or `:sm`
   # @param close_button [Boolean] display a close button to remove the alert
+  # @note in size MD the title is required but the content is optional. In size SM there should be not title but the content is required
   def initialize(type:, title: nil, size: :md, close_button: false, classes: [], html_attributes: {})
     @title = title
     @type = type
@@ -16,6 +17,9 @@ class DsfrComponent::AlertComponent < DsfrComponent::Base
   end
 
   def call
+    raise ArgumentError, "SM alerts cannot have titles but must have a content" if @size == :sm && (@title.present? || content.blank?)
+    raise ArgumentError, "MD Alerts must have a title" if @size == :md && @title.blank?
+
     tag.div(**html_attributes) do
       safe_join([title_tag, content_tag, close_button_tag])
     end
@@ -30,6 +34,8 @@ private
   end
 
   def title_tag
+    return nil if title.blank?
+
     tag.h3(class: "fr-alert__title") { title }
   end
 

--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -1,5 +1,6 @@
 module DsfrComponentsHelper
   {
+    dsfr_alert: 'DsfrComponent::AlertComponent',
     dsfr_accordion: 'DsfrComponent::AccordionComponent',
     dsfr_back_link: 'DsfrComponent::BackLinkComponent',
     dsfr_breadcrumbs: 'DsfrComponent::BreadcrumbsComponent',

--- a/guide/content/components/alert.slim
+++ b/guide/content/components/alert.slim
@@ -1,0 +1,29 @@
+---
+title: Alerte
+---
+
+p Les alertes permettent d’attirer l’attention de l’utilisateur sur une information sans interrompre sa tâche en cours.
+
+== render('/partials/example.*',
+  caption: "Alerte de succès avec du contenu",
+  code: alert_success_with_content) do
+
+  markdown:
+    Une alerte a un `type` obligatoire parmi `:error`, `:success`, `:info`, `:warning`.
+
+    Le titre `title` est aussi obligatoire
+
+== render('/partials/example.*',
+  caption: "Alerte d'erreur taille SM sans contenu",
+  code: alert_error_sm_without_content) do
+
+  markdown:
+    La taille `size` peut être `:sm` ou `:md` (le défaut).
+
+    En taille SM le contenu n'est pas obligatoire
+
+== render('/partials/example.*',
+  caption: "Alerte avec un bouton pour fermer",
+  code: alert_with_close_button)
+
+== render('/partials/related-info.*', links: alert_info)

--- a/guide/content/components/alert.slim
+++ b/guide/content/components/alert.slim
@@ -6,25 +6,30 @@ p Les alertes permettent d’attirer l’attention de l’utilisateur sur une in
 p Il existe deux tailles d'alertes : MD (par défaut) et SM. En taille MD l'alerte doit avoir un titre et peut avoir un contenu. En taille SM l'alerte ne peut pas avoir de titre et doit avoir un contenu.
 
 == render('/partials/example.*',
-  caption: "Alerte de succès avec du contenu",
-  code: alert_success_with_content) do
+  caption: "Alerte MD de succès avec du contenu",
+  code: alert_md_success_with_content) do
 
   markdown:
     Une alerte a un `type` obligatoire parmi `:error`, `:success`, `:info` ou `:warning`.
 
-    Le titre `title` est aussi obligatoire
+== render('/partials/example.*',
+  caption: "Alerte MD de succès sans contenu",
+  code: alert_md_success_with_content) do
+
+  markdown:
+    En taille MD, le titre `title` est obligatoire pour les alertes mais le contenu est optionnel
 
 == render('/partials/example.*',
   caption: "Alerte d'erreur taille SM sans contenu",
-  code: alert_error_sm_without_content) do
+  code: alert_sm_error) do
 
   markdown:
-    La taille `size` peut être `:sm` ou `:md` (le défaut).
+    La taille `size` peut être `:sm` ou `:md` (par défaut).
 
-    En taille SM le contenu n'est pas obligatoire
+    A l'inverse, en taille SM il ne peut pas y avoir de titre mais le contenu est obligatoire
 
 == render('/partials/example.*',
   caption: "Alerte avec un bouton pour fermer",
-  code: alert_with_close_button)
+  code: alert_md_with_close_button)
 
 == render('/partials/related-info.*', links: alert_info)

--- a/guide/content/components/alert.slim
+++ b/guide/content/components/alert.slim
@@ -3,13 +3,14 @@ title: Alerte
 ---
 
 p Les alertes permettent d’attirer l’attention de l’utilisateur sur une information sans interrompre sa tâche en cours.
+p Il existe deux tailles d'alertes : MD (par défaut) et SM. En taille MD l'alerte doit avoir un titre et peut avoir un contenu. En taille SM l'alerte ne peut pas avoir de titre et doit avoir un contenu.
 
 == render('/partials/example.*',
   caption: "Alerte de succès avec du contenu",
   code: alert_success_with_content) do
 
   markdown:
-    Une alerte a un `type` obligatoire parmi `:error`, `:success`, `:info`, `:warning`.
+    Une alerte a un `type` obligatoire parmi `:error`, `:success`, `:info` ou `:warning`.
 
     Le titre `title` est aussi obligatoire
 

--- a/guide/lib/examples/alert_helpers.rb
+++ b/guide/lib/examples/alert_helpers.rb
@@ -2,21 +2,25 @@ module Examples
   module AlertHelpers
     def alert_success_with_content
       <<~ALERT
-        = dsfr_alert(type: :success, title: "Bravo bien joué") do |alert|
-          | Belle partie !
+        = dsfr_alert(type: :success, title: "Succès d'inscription") do |alert|
+          | Votre inscription a bien été enregistrée
       ALERT
     end
 
     def alert_error_sm_without_content
       <<~ALERT
-        = dsfr_alert(type: :error, size: :sm, title: "Erreur db 123")
+        = dsfr_alert( \
+          type: :error, \
+          size: :sm, \
+          title: "Une erreur est survenue pendant votre inscription, veuillez contacter votre administrateur." \
+        )
       ALERT
     end
 
     def alert_with_close_button
       <<~ALERT
         = dsfr_alert(type: :success, title: "Bienvenue", close_button: true) do
-          | Merci de vous être inscrit·e
+          | Merci pour votre inscription
       ALERT
     end
   end

--- a/guide/lib/examples/alert_helpers.rb
+++ b/guide/lib/examples/alert_helpers.rb
@@ -1,20 +1,26 @@
 module Examples
   module AlertHelpers
-    def alert_success_with_content
+    def alert_md_success_with_content
       <<~ALERT
-        = dsfr_alert(type: :success, title: "Succès d'inscription") do |alert|
+        = dsfr_alert(type: :success, title: "Succès de votre inscription") do |alert|
           | Votre inscription a bien été enregistrée
       ALERT
     end
 
-    def alert_error_sm_without_content
+    def alert_md_success_without_content
+      <<~ALERT
+        = dsfr_alert(type: :success, title: "Succès de votre inscription")
+      ALERT
+    end
+
+    def alert_sm_error
       <<~ALERT
         = dsfr_alert(type: :error, size: :sm) do
           | Une erreur est survenue pendant votre inscription, veuillez contacter votre administrateur
       ALERT
     end
 
-    def alert_with_close_button
+    def alert_md_with_close_button
       <<~ALERT
         = dsfr_alert(type: :success, title: "Bienvenue", close_button: true) do
           | Merci pour votre inscription

--- a/guide/lib/examples/alert_helpers.rb
+++ b/guide/lib/examples/alert_helpers.rb
@@ -9,11 +9,8 @@ module Examples
 
     def alert_error_sm_without_content
       <<~ALERT
-        = dsfr_alert( \
-          type: :error, \
-          size: :sm, \
-          title: "Une erreur est survenue pendant votre inscription, veuillez contacter votre administrateur." \
-        )
+        = dsfr_alert(type: :error, size: :sm) do
+          | Une erreur est survenue pendant votre inscription, veuillez contacter votre administrateur
       ALERT
     end
 

--- a/guide/lib/examples/alert_helpers.rb
+++ b/guide/lib/examples/alert_helpers.rb
@@ -1,0 +1,23 @@
+module Examples
+  module AlertHelpers
+    def alert_success_with_content
+      <<~ALERT
+        = dsfr_alert(type: :success, title: "Bravo bien joué") do |alert|
+          | Belle partie !
+      ALERT
+    end
+
+    def alert_error_sm_without_content
+      <<~ALERT
+        = dsfr_alert(type: :error, size: :sm, title: "Erreur db 123")
+      ALERT
+    end
+
+    def alert_with_close_button
+      <<~ALERT
+        = dsfr_alert(type: :success, title: "Bienvenue", close_button: true) do
+          | Merci de vous être inscrit·e
+      ALERT
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -26,6 +26,7 @@ require 'components/dsfr_component'
 require 'components/dsfr_component/traits'
 require 'components/dsfr_component/traits/custom_html_attributes'
 require 'components/dsfr_component/base'
+require 'components/dsfr_component/alert_component'
 require 'components/dsfr_component/accordion_component'
 require 'components/dsfr_component/accordion_component/section_component'
 require 'components/dsfr_component/back_link_component'
@@ -66,6 +67,7 @@ require 'helpers/dsfr_link_helper'
 use_helper DsfrLinkHelper
 use_helper DsfrComponentsHelper
 use_helper Examples::LinkHelpers
+use_helper Examples::AlertHelpers
 use_helper Examples::AccordionHelpers
 use_helper Examples::BreadcrumbsHelpers
 use_helper Examples::BackLinkHelpers

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -19,6 +19,12 @@ module Helpers
       )
     end
 
+    def alert_info
+      {
+        "Documentation Alertes - Alerts sur la documentation du Système de Design de lʼÉtat" => "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/alerte/"
+      }
+    end
+
     def accordion_info
       {
         "GOV.UK Design System accordion documentation" => "https://design-system.service.gov.uk/components/accordion/"
@@ -119,24 +125,7 @@ module Helpers
 
     def component_helper_mapping
       {
-        "DsfrComponent::AccordionComponent" => "dsfr_accordion",
-        "DsfrComponent::BackLinkComponent" => "dsfr_back_link",
-        "DsfrComponent::BreadcrumbsComponent" => "dsfr_breadcrumbs",
-        "DsfrComponent::CookieBannerComponent" => "dsfr_cookie_banner",
-        "DsfrComponent::DetailsComponent" => "dsfr_details",
-        "DsfrComponent::FooterComponent" => "dsfr_footer",
-        "DsfrComponent::HeaderComponent" => "dsfr_header",
-        "DsfrComponent::InsetTextComponent" => "dsfr_inset_text",
-        "DsfrComponent::NotificationBannerComponent" => "dsfr_notification_banner",
-        "DsfrComponent::PaginationComponent" => "dsfr_pagination",
-        "DsfrComponent::PanelComponent" => "dsfr_panel",
-        "DsfrComponent::PhaseBannerComponent" => "dsfr_phase_banner",
-        "DsfrComponent::StartButtonComponent" => "dsfr_start_button",
-        "DsfrComponent::SummaryListComponent" => "dsfr_summary_list",
-        "DsfrComponent::TableComponent" => "dsfr_table",
-        "DsfrComponent::TabComponent" => "dsfr_tabs",
-        "DsfrComponent::TagComponent" => "dsfr_tag",
-        "DsfrComponent::WarningTextComponent" => "dsfr_warning_text",
+        "DsfrComponent::AlertComponent" => "dsfr_alert",
       }
     end
   end

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -8,8 +8,8 @@ module Helpers
   module LinkHelpers
     def component_links
       {
-        # "Alerte" => "/components/alert",
-        "Accordion" => "/components/accordion",
+        "Alerte" => "/components/alert",
+        # "Accordion" => "/components/accordion",
         # "Back link" => "/components/back-link",
         # "Breadcrumbs" => "/components/breadcrumbs",
         # "Cookie banner" => "/components/cookie-banner",

--- a/spec/components/dsfr_component/alert_component_spec.rb
+++ b/spec/components/dsfr_component/alert_component_spec.rb
@@ -29,16 +29,32 @@ RSpec.describe(DsfrComponent::AlertComponent, type: :component) do
     end
   end
 
-  context "when type success without content with size sm" do
+  context "when size SM" do
     subject! do
-      render_inline(described_class.new(type: :success, title: "Erreur numéro 123", size: :sm))
+      render_inline(described_class.new(type: :success, size: :sm).with_content("Inscription réussie !"))
     end
 
-    it "renders both title and content" do
+    it "renders only the content" do
       expect(rendered_content).to have_tag('div', with: { class: "fr-alert fr-alert--success fr-alert--sm" }) do
-        with_tag("h3", with: { class: "fr-alert__title" }, text: "Erreur numéro 123")
-        without_tag("p")
+        without_tag("h3")
+        with_tag("p", text: "Inscription réussie !")
       end
+    end
+  end
+
+  context "when size sm with a title but no content" do
+    it "raises ArgumentError" do
+      expect do
+        render_inline(described_class.new(type: :success, title: "Erreur numéro 123", size: :sm))
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  context "when size md with content but no title" do
+    it "raises ArgumentError" do
+      expect do
+        render_inline(described_class.new(type: :success, size: :md)) { "L'heure est grave" }
+      end.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/components/dsfr_component/alert_component_spec.rb
+++ b/spec/components/dsfr_component/alert_component_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+RSpec.describe(DsfrComponent::AlertComponent, type: :component) do
+  context "when type error with content" do
+    subject! do
+      render_inline(described_class.new(type: :error, title: "Erreur numéro 123")) do
+        "La base de données est en carafe"
+      end
+    end
+
+    it "renders both title and content" do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-alert fr-alert--error" }) do
+        with_tag("h3", with: { class: "fr-alert__title" }, text: "Erreur numéro 123")
+        with_tag("p", text: "La base de données est en carafe")
+      end
+    end
+  end
+
+  context "when type error without content" do
+    subject! do
+      render_inline(described_class.new(type: :error, title: "Erreur numéro 123"))
+    end
+
+    it "renders both title and content" do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-alert fr-alert--error" }) do
+        with_tag("h3", with: { class: "fr-alert__title" }, text: "Erreur numéro 123")
+        without_tag("p")
+      end
+    end
+  end
+
+  context "when type success without content with size sm" do
+    subject! do
+      render_inline(described_class.new(type: :success, title: "Erreur numéro 123", size: :sm))
+    end
+
+    it "renders both title and content" do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-alert fr-alert--success fr-alert--sm" }) do
+        with_tag("h3", with: { class: "fr-alert__title" }, text: "Erreur numéro 123")
+        without_tag("p")
+      end
+    end
+  end
+
+  context "when type warning with content and close button" do
+    subject! do
+      render_inline(described_class.new(type: :warning, title: "Erreur numéro 123", close_button: true)) do
+        "fermez moi"
+      end
+    end
+
+    it "renders both title and content" do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-alert fr-alert--warning" }) do
+        with_tag("h3", with: { class: "fr-alert__title" }, text: "Erreur numéro 123")
+        with_tag("p", text: "fermez moi")
+        with_tag("button", with: { class: "fr-btn--close fr-btn" })
+      end
+    end
+  end
+
+  context "when erroneous type blague" do
+    it "raises ArgumentError" do
+      expect do
+        render_inline(described_class.new(type: :blague, title: "Erreur numéro 123"))
+      end.to raise_error(ArgumentError, /invalid alert type/)
+    end
+  end
+
+  context "when erroneous size lg" do
+    it "raises ArgumentError" do
+      expect do
+        render_inline(described_class.new(type: :success, title: "Erreur numéro 123", size: :lg))
+      end.to raise_error(ArgumentError, /invalid alert size/)
+    end
+  end
+
+  # it_behaves_like 'a component that accepts custom classes'
+  # it_behaves_like 'a component that accepts custom HTML attributes'
+end

--- a/spec/dummy/app/views/demos/examples/_alert.html.erb
+++ b/spec/dummy/app/views/demos/examples/_alert.html.erb
@@ -1,8 +1,21 @@
 <%= example_heading('Alertes - Alert') %>
 
-<%= render "shared/example", title: "Alert", example: <<~ALERT
-  render DsfrComponent::AlertComponent.new(title: 'Erreur : titre du message') do
+<%= render "shared/example", title: "Alerte succès", example: <<~ALERT
+  render DsfrComponent::AlertComponent.new(title: 'Bravo ! merci', type: :success)
+  ALERT
+%>
+
+<%= render "shared/example", title: "Alerte erreur avec une description", example: <<~ALERT
+  render DsfrComponent::AlertComponent.new(title: 'Erreur : titre du message', type: :error) do
     "Ceci est une alerte d'erreur"
+  end
+  ALERT
+%>
+
+
+<%= render "shared/example", title: "Alerte succès avec bouton pour fermer", example: <<~ALERT
+  render DsfrComponent::AlertComponent.new(title: 'Erreur : titre du message', type: :error, close_button: true) do
+    "cliquez sur la croix pour fermer"
   end
   ALERT
 %>


### PR DESCRIPTION
cf #58 

![image](https://user-images.githubusercontent.com/883348/203754133-a497c1cb-7741-48a3-a70e-a2f0180c4138.png)


![image](https://user-images.githubusercontent.com/883348/203754042-bdd87816-31cd-48ac-bb04-6447400c6fe0.png)



## Title

j'hésite un peu pour le `title` est-ce qu'on devrait utiliser un slot ou un kwarg comme j'ai fait la ? Je n'ai pas trop d'avis

## Style des tests

Sur mon "style" d'ecriture des tests  : je générise au minimum les exemples pour que chaque exemple soit lisible de manière contenue sans avoir besoin de se référer à trois niveaux d'héritages, de déclarations de variables dans des contextes RSpec différents.

C'est assez différent de l'approche govuk mais pour le coup elle ne me convient pas trop je trouve leurs tests assez illisible.

## spec behaviours communs

je n'ai pas encore activé les comportements de tests communs pour accepter les classes : 

```rb
# it_behaves_like 'a component that accepts custom classes'
# it_behaves_like 'a component that accepts custom HTML attributes'
```

mais ca fera plutot l'affaire d'une autre PR a mon avis

## helpers

j'ai supprimé le mapping des helpers dans `guide/lib/helpers/content_helpers.rb` des components existants de govuk pour faire de la place et passer le lint ^^ ça aurait plutôt du etre dans une autre PR