### PR TITLE
passage de rubocop-govuk a rubocop classique

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,55 +1,16 @@
 ---
-inherit_gem:
-  rubocop-govuk:
-    - config/default.yml
-    - config/rails.yml
-
-AllCops:
-  TargetRubyVersion: 2.7
-  Exclude:
-    - dsfr_design_system_formbuilder.gemspec
-    - spec/dummy/**/*
-Security/Eval:
-  Exclude:
-    - guide/lib/helpers/formatters.rb
-Lint/MissingSuper:
-  Enabled: false
-Rails/Date:
-  Enabled: false
-Rails/ActiveSupportAliases:
-  Enabled: false
-Style/StringLiterals:
-  Enabled: false
-Style/TrailingCommaInArguments:
-  Enabled: false
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-Style/Lambda:
-  Enabled: false
-Style/StringConcatenation:
-  Enabled: false
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-Style/TernaryParentheses:
-  Enabled: false
-Style/RedundantParentheses:
-  Enabled: false
-Naming/MethodParameterName:
-  Enabled: false
-Style/PercentLiteralDelimiters:
-  Enabled: false
-Layout/HashAlignment:
-  Enabled: false
-Style/SignalException:
-  Enabled: false
-Style/Proc:
-  Enabled: false
-Style/AsciiComments:
-  Enabled: false
-Style/FormatString:
-  EnforcedStyle: format
-Gemspec/RequiredRubyVersion:
-  Enabled: false
+require:
+  - rubocop-rails
+  - rubocop-rspec
+inherit_from:
+  - ./config/rubocop-default.yml
+  - ./config/rubocop-rails.yml
+  - ./config/rubocop-rspec.yml
+  - ./config/rubocop-govuk-components.yml
+  - ./config/rubocop-dsfr-overrides.yml
+inherit_mode:
+  merge:
+    - Exclude
 Style/MixinUsage:
   Exclude:
     - spec/spec_helper.rb

--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gemspec
 group 'nanoc' do
   gem 'nanoc-live'
 end
+
+gem "rubocop-rspec", "~> 2.14"

--- a/config/rubocop-default.yml
+++ b/config/rubocop-default.yml
@@ -1,3 +1,5 @@
+# from https://github.com/alphagov/rubocop-govuk/blob/main/config/default.yml
+
 AllCops:
   NewCops: disable
   SuggestExtensions: false

--- a/config/rubocop-default.yml
+++ b/config/rubocop-default.yml
@@ -1,0 +1,26 @@
+AllCops:
+  NewCops: disable
+  SuggestExtensions: false
+  Exclude:
+    - 'bin/**'
+    - 'config.ru'
+    - 'tmp/**/*'
+    - 'db/schema.rb'
+    - 'db/migrate/201*'
+    - 'vendor/**/*'
+    - 'node_modules/**/*'
+
+  DisplayCopNames:
+    Enabled: true
+
+  ExtraDetails:
+    Enabled: true
+
+  DisplayStyleGuide:
+    Enabled: true
+
+inherit_from:
+  - rubocop-layout.yml
+  - rubocop-metrics.yml
+  - rubocop-naming.yml
+  - rubocop-style.yml

--- a/config/rubocop-dsfr-overrides.yml
+++ b/config/rubocop-dsfr-overrides.yml
@@ -1,0 +1,28 @@
+RSpec/DescribedClass:
+  Enabled: false
+RSpec/LeadingSubject:
+  Enabled: false
+RSpec/FilePath:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: false
+RSpec/AnyInstance:
+  Enabled: false
+RSpec/MultipleDescribes:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/VerifiedDoubles:
+  Enabled: false
+RSpec/VoidExpect:
+  Enabled: false
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+RSpec/ScatteredLet:
+  Enabled: false
+RSpec/EmptyLineAfterSubject:
+  Enabled: false
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false

--- a/config/rubocop-govuk-components.yml
+++ b/config/rubocop-govuk-components.yml
@@ -1,3 +1,5 @@
+# from https://github.com/DFE-Digital/govuk-components/blob/main/.rubocop.yml
+
 AllCops:
   TargetRubyVersion: 2.7
   Exclude:

--- a/config/rubocop-govuk-components.yml
+++ b/config/rubocop-govuk-components.yml
@@ -1,0 +1,46 @@
+AllCops:
+  TargetRubyVersion: 2.7
+  Exclude:
+    - dsfr_design_system_formbuilder.gemspec
+    - spec/dummy/**/*
+Security/Eval:
+  Exclude:
+    - guide/lib/helpers/formatters.rb
+Lint/MissingSuper:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+Rails/ActiveSupportAliases:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false
+Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+Style/Lambda:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TernaryParentheses:
+  Enabled: false
+Style/RedundantParentheses:
+  Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Style/SignalException:
+  Enabled: false
+Style/Proc:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/FormatString:
+  EnforcedStyle: format
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/config/rubocop-layout.yml
+++ b/config/rubocop-layout.yml
@@ -1,3 +1,5 @@
+# from https://github.com/alphagov/rubocop-govuk/blob/main/config/layout.yml
+
 # https://github.com/alphagov/govuk-lint/pull/7
 # "There are occasions where following this rule forces you to make the
 # code less readable. This is particularly the case for tests where method

--- a/config/rubocop-layout.yml
+++ b/config/rubocop-layout.yml
@@ -1,0 +1,78 @@
+# https://github.com/alphagov/govuk-lint/pull/7
+# "There are occasions where following this rule forces you to make the
+# code less readable. This is particularly the case for tests where method
+# names form the test descriptions. Keeping test descriptions under a
+# certain length can force them to become cryptic."
+Layout/LineLength:
+  Enabled: false
+
+# We have two styles of method call in our apps:
+#
+# SomeClass.first_method_call_on_same_line
+#          .other_method_call
+#
+# a_particularly_long_first_method_call
+#   .subsequent_method_call
+#
+# Any setting of this Cop would cause odd alignment
+# for one of these styles. Since there isn't a Cop to
+# set a preferred style, we should disable this one.
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+# Part of the orignal GDS styleguide
+# "Outdent private etc"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#classes
+Layout/AccessModifierIndentation:
+  Enabled: true
+  EnforcedStyle: outdent
+
+# Our predominant style of writing multiline arrays is:
+#
+# my_array = [
+#   element_1,
+#   element_2,
+# ]
+#
+# even_in_a_method_call([
+#   element_1,
+#   element_2,
+# ])
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+# Our predominant style of writing multiline hashes is:
+#
+# my_hash = {
+#   key_1: value_1,
+#   key_2: value_2,
+# }
+#
+# even_in_a_method_call({
+#   key_1: value_1,
+#   key_2: value_2,
+# })
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+# Our predominant style of writing multiline operations is
+# to indent the subsequent lines. This helps to prevent
+# misreading the next line as a new/separate statement.
+#
+# Introduced in: 9b2a744ab119d7797aaf423abcec914360f4208e
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+# We should be consistent: if some items of an array are
+# on multiple lines, then all items should be. This works
+# better with the indentation Cops, produces clearer diffs,
+# and avoids wasting time tweaking an arbitrary layout.
+Layout/MultilineArrayLineBreaks:
+  Enabled: true
+
+# We should be consistent: if some items of a hash are
+# on multiple lines, then all items should be. This works
+# better with the indentation Cops, produces clearer diffs,
+# and avoids wasting time tweaking an arbitrary layout.
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true

--- a/config/rubocop-metrics.yml
+++ b/config/rubocop-metrics.yml
@@ -1,3 +1,5 @@
+# from https://github.com/alphagov/rubocop-govuk/blob/main/config/metrics.yml
+
 # Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
 #
 # We should avoid cops that are based on heuristics, since

--- a/config/rubocop-metrics.yml
+++ b/config/rubocop-metrics.yml
@@ -1,0 +1,73 @@
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+#
+# For this Cop, there are also several kinds of file that
+# have long blocks by convention (tests, config, rake tasks,
+# gemspecs), to the point where its value is dubious.
+Metrics/BlockLength:
+  Enabled: false
+
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/AbcSize:
+  Enabled: false
+
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/ClassLength:
+  Enabled: false
+
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/ModuleLength:
+  Enabled: false
+
+# Introduced in: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/BlockNesting:
+  Enabled: false
+
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/MethodLength:
+  Enabled: false
+
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Metrics/ParameterLists:
+  Enabled: false

--- a/config/rubocop-naming.yml
+++ b/config/rubocop-naming.yml
@@ -1,3 +1,5 @@
+# from https://github.com/alphagov/rubocop-govuk/blob/main/config/naming.yml
+
 # Conflicts with the original GDS styleguide
 #
 # While this may conflict with the original GDS styleguide, there

--- a/config/rubocop-naming.yml
+++ b/config/rubocop-naming.yml
@@ -1,0 +1,28 @@
+# Conflicts with the original GDS styleguide
+#
+# While this may conflict with the original GDS styleguide, there
+# are times where we wish to call a method that "sets" something.
+#
+# def set_political_and_government(edition)
+#
+# The original styleguide only accounts for a specific kind of "set"
+# operation, where the argument is the value being assigned.
+#
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#naming
+Naming/AccessorMethodName:
+  Enabled: false
+
+# We should be free to decide on interfaces that make sense to us.
+# At the time of writing, this Cop is not auto-correctable, and
+# would generate a prohibitively high number of issues across our
+# repos, which would require manual intervention.
+Naming/PredicateName:
+  Enabled: false
+
+# This rule can cause readability issues when applied (for example
+# `born_on_or_before_6_april_1935` becomes `born_on_or_before_6april1935`)
+# and would require lots of amends to apply either `normalcase`
+# or `snake_case` to projects. It is not auto-correctable.
+Naming/VariableNumber:
+  Enabled: false

--- a/config/rubocop-rails.yml
+++ b/config/rubocop-rails.yml
@@ -1,3 +1,5 @@
+# from https://github.com/alphagov/rubocop-govuk/blob/main/config/rails.yml
+
 ##################### Rails ##################################
 
 # By default Rails is switched off so this can be used by non-Rails apps,

--- a/config/rubocop-rails.yml
+++ b/config/rubocop-rails.yml
@@ -1,0 +1,94 @@
+##################### Rails ##################################
+
+# By default Rails is switched off so this can be used by non-Rails apps,
+# this can be enabled in a local .rubocop.yml file
+
+require: rubocop-rails
+
+AllCops:
+  Exclude:
+    - 'db/schema.rb'
+    - 'db/migrate/201*'
+
+Rails:
+  Enabled: true
+
+# We have custom find_by methods in several repos, which
+# we're not going to rename. This Cop also raises false
+# positives for find_by methods that are unrelated to model
+# classes, as well as for repos using Mongoid. The value
+# of the consistency this brings is limited, since we mostly
+# use find_by(key: value) anyway.
+#
+# https://github.com/rubocop-hq/rubocop/issues/3758
+Rails/DynamicFindBy:
+  Enabled: false
+
+# We commonly print output in Ruby code that has been
+# extracted from a Rake task in 'lib/'.
+Rails/Output:
+  Exclude:
+    - 'lib/**/*.rb'
+
+# It's unclear what remedial action to take for the total
+# set of methods this Cop has issues with. For example, we
+# use 'update_all' in many of our repos, for which there is
+# no efficient alternative. Instead, we should only enable
+# this Cop for methods that have a clear alternative.
+Rails/SkipsModelValidations:
+  ForbiddenMethods:
+    - update_attribute
+
+# While using has_many/through does have some advantages,
+# it also requires a significant amount of boilerplate code:
+#
+# - An additional 'has_many :join_table' statement
+# - An additional class for the join table (model)
+#
+# This Cop/rule appears to have been written with the
+# assumption that all join tables have inherent meaning,
+# we want to represent, which is not the case; sometimes
+# relationships are just # many-to-many, and that's it.
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+# While using 'inverse_of' can reduce DB queries, we have
+# not found this to be a problem in practice. The advantage
+# of turning this on would be that we make the inverse
+# behaviour explicit everywhere ActiveRecord can't apply it
+# automatically, but this is rarely a surprise for developers.
+# We also don't want to add 'inverse_of: false' everywhere;
+# at the time of writing, there is no auto-correct for this.
+Rails/InverseOf:
+  Enabled: false
+
+# This is incompatible with the more robust use of foreign
+# key constraints, which provide the same behaviour.
+#
+# Example: https://github.com/alphagov/content-publisher/blob/f26d9b551842fdf2084159b5b7f1bb078da56936/db/schema.rb#L396
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
+# We commonly want to render HTML without escaping it, which
+# is what 'html_safe' is for. In many cases, the content we
+# render has already been sanitised (e.g. through Govspeak),
+# or is otherwise trusted e.g. from a content item. We trust
+# that developers will use 'html_safe' responsibly, and prefer
+# the default, escaped output otherwise. At the time of writing,
+# this Cop is disabled in a lot of repos, indicating it offers
+# little value to many developers.
+Rails/OutputSafety:
+  Enabled: false
+
+# We seldom check the return value of 'update' to see if
+# the operation was successful. Since we assume success, we
+# should raise an exception if this is not the case.
+Rails/SaveBang:
+  Enabled: true
+
+# We should avoid unnecessary ambiguity between 'Time.current'
+# and 'Time.zone.now', where 'Time.current' behaves differently
+# depending on application config. We should always be explicit
+# about whether we mean 'Time[.zone].now'.
+Rails/TimeZone:
+  EnforcedStyle: "strict"

--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,3 +1,5 @@
+# from https://github.com/alphagov/rubocop-govuk/blob/main/config/rspec.yml
+
 # Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
 #
 # We should avoid cops that are based on heuristics, since

--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,0 +1,47 @@
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+RSpec/ExampleLength:
+  Enabled: false
+
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+# We have common cases, such as rake tasks, where we do not
+# use a class to the describe the test.
+RSpec/DescribeClass:
+  Enabled: false
+
+# We accept multiple expectations (within reason), preferring
+# them to running mulitple similar tests.
+RSpec/MultipleExpectations:
+  Enabled: false
+
+# Part of the GOV.UK feature style involves instance variables.
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/features/**/*.rb'
+
+# In GOV.UK we quite often test that a class received a method.
+RSpec/MessageSpies:
+  Enabled: false
+
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+RSpec/NestedGroups:
+  Enabled: false
+
+# Nested contexts make more sense with "and" or "but", since
+# they are a refinement of an outer context.
+RSpec/ContextWording:
+  Prefixes:
+    - when
+    - with
+    - without
+    - and
+    - but

--- a/config/rubocop-style.yml
+++ b/config/rubocop-style.yml
@@ -1,3 +1,5 @@
+# from https://github.com/alphagov/rubocop-govuk/blob/main/config/style.yml
+
 # https://github.com/alphagov/govuk-lint/pull/36
 # "When we have sequence of if/unless statements,
 # some with multiple lines within the if statement

--- a/config/rubocop-style.yml
+++ b/config/rubocop-style.yml
@@ -1,0 +1,155 @@
+# https://github.com/alphagov/govuk-lint/pull/36
+# "When we have sequence of if/unless statements,
+# some with multiple lines within the if statement
+# block and some with a single line, forcing the single
+# line statements to re-written makes it a harder
+# to follow the branching logic."
+Style/IfUnlessModifier:
+  Enabled: false
+
+# Part of the orignal GDS styleguide
+# "Never chain do...end"
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#syntax
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+
+# Part of the orignal GDS styleguide
+# "Add a trailing comma to multi-line array [...]
+# for clearer diffs with less line noise."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+# Part of the orignal GDS styleguide
+# "Add a trailing comma to multi-line hash definitions [...]
+# for clearer diffs with less line noise."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+# Part of the orignal GDS styleguide
+# "When long lists of method arguments require
+# breaking over multiple lines, break each successive
+# argument on a new line, including the first argument
+# and closing paren. The final argument should include
+# a trailing comma."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#general
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+# Part of the orignal GDS styleguide
+# "Prefer %w to the literal array syntax when you need
+# an array of strings."
+# https://github.com/alphagov/styleguides/blob/6395a10d41c3938f4c147cda443fd83f854c3e7a/ruby.md#collections
+Style/WordArray:
+  MinSize: 0
+
+# "Try not to mix up single-quoted and double-quoted
+# strings within a file: it can make the code harder to read.
+# Definitely don't mix up single-quoted and double-quoted
+# strings within a method. If in doubt, use double-quoted strings,
+# because you’ll probably need to use interpolation somewhere.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# Introduced in: 5ca6b7d20fd62a6ce890868abdeca12837e436d7
+# "The wording of the description is hard to understand - it's not
+# immediately obvious what you have to do, and doesn't really say why
+# this is a good thing.
+#
+# It's not auto-fixable, which means it takes a lot of time to get the
+# syntax right for every occurrence of `%.2f` for example (taken from
+# `smart-answers`) for not very much benefit."
+Style/FormatStringToken:
+  Enabled: false
+
+# Using the default style leads to buggy auto-correct in several
+# repos that have their own 'format' method defined. While it's not
+# ideal to override a standard/Kernel method, it's also not practical
+# to change a term that's so deeply embedded within our domain.
+#
+# Related PR: https://github.com/alphagov/specialist-publisher/pull/1640
+# Related PR: https://github.com/alphagov/publisher/pull/1268
+Style/FormatString:
+  EnforcedStyle: sprintf
+
+# This is a contentious issue, since 'alias_method' works in
+# all circumstances, whereas 'alias' only works lexically. As
+# with single vs. double quotes, it seems pointless to expend
+# effort deciding between them. Our predominant style is to use
+# 'alias_method', which always works.
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+# This prevents weird characters in comments, such as stylistic
+# quote characters and strange whitespace. We should only allow
+# special characters when they are essential for a comment. It's
+# a waste of effort to go and find the special sequence when an
+# alternative exists e.g. '×' can be replaced with '*' in maths.
+Style/AsciiComments:
+  AllowedChars: ['£']
+
+# We should only use braces in multiline blocks in a # chained
+# method call. This is consistent with the RSpec 'expect' syntax.
+#
+# expect {
+#   a_long_and_complex_method_call
+# }.to raise_error(SomeError)
+#
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining
+
+# We have no concensus on this. Using the nested style is the
+# default for generated Rails app (see 'config/application.rb').
+# Using the compact style can help to reduce boilerplate within
+# modules. At the time of writing, the auto-correct for this Cop
+# is unsafe for moving to either style.
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# Documenting every class is a lot of effort and we don't
+# expect to get any value from this. Another risk of adding
+# more documentation is the potential for confusion if that
+# documentation gets out-of-sync with the class/module.
+Style/Documentation:
+  Enabled: false
+
+# Introduced in: c69a7eb3af955d6c4c0cf0c3cec8e9f330c74429
+# This can lead to excessively long lines. Consistent with
+# disabling "Layout/LineLength".
+#
+# "There are occasions where following this rule forces you to make the
+# code less readable."
+Style/GuardClause:
+  Enabled: false
+
+# Analog of: 736b3d295f88b9ba6676fc168b823535582388c2
+# "Disable opinionated cops"
+#
+# We should avoid cops that are based on heuristics, since
+# it's not clear what action to take to fix an issue.
+Style/RegexpLiteral:
+  Enabled: false
+
+# Using safe navigation is less explicit than making a clear
+# check for truthiness, as evidenced by its own safelist for
+# certain methods. Safe navigation is also less visible and
+# pollutes otherwise readable method calls.
+Style/SafeNavigation:
+  Enabled: false
+
+# Introduced in: b171d652d3e434b74ddc621df3b5be24c49bc7e8
+# This cop was added in preperation for a Ruby feature
+# that is no longer likely to become part of the language.
+# https://github.com/rubocop-hq/rubocop/issues/7197
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# We should only use DateTime when it's necessary to account
+# for ancient calendar changes. Otherwise, the arbitrary use
+# of this class in place of Date or Time is confusing.
+#
+# https://rubystyle.guide/#no-datetime
+Style/DateTime:
+  Enabled: true

--- a/dsfr-components.gemspec
+++ b/dsfr-components.gemspec
@@ -38,7 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.9"
   spec.add_development_dependency "rspec-rails"
-  spec.add_development_dependency "rubocop-govuk", "= 4.0.0"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop-rails"
   spec.add_development_dependency "sassc-rails"
   spec.add_development_dependency("simplecov", "~> 0.20")
   spec.add_development_dependency "sqlite3"


### PR DESCRIPTION
cf #102 reparer lint rubocop

la dependance sur `rubocop-govuk` ne me parait pas très judicieuse à préserver : 

- ça dépend d'une version de rubocop un peu ancienne si je comprends bien 1.15
- on va probablement vouloir en diverger
- il n'y a pas vraiment de raison qu'on garde les mêmes règles de lint que govuk

changements de la PR

- retrait de la dépendance `rubocop-govuk` 
- ajout de dependances sur `rubocop` `rubocop-rails` et `rubocop-rspec`
- copie des configs et fichiers de config `rubocop` depuis la gem `rubocop-govuk`
- ajout d'un fichier de config rubocop d'overrides perso pour dsfr-components, pour faire en sorte que le lint passe

on pourra retirer peu a peu les overrides des fichiers de config si on le souhaite