### PR TITLE
doc: fix yard server locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ guide/content/assets/images
 guide/content/javascripts/*
 guide/content/stylesheets/fonts/*
 guide/content/stylesheets/icons/*
+.yardoc

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ view-guide: build-guide
 watch-guide: npm-install
 	( ${guide_dir} ${prefix} nanoc live --port ${nanoc_default_port} )
 docs-server:
-	yard server --reload
+	bundle exec yard server --reload
 code-climate:
 	codeclimate analyze {lib,spec,guide/lib}
 clean:

--- a/dsfr-components.gemspec
+++ b/dsfr-components.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sassc-rails"
   spec.add_development_dependency("simplecov", "~> 0.20")
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "yard"
 
   # Required for the guide
   spec.add_development_dependency("htmlbeautifier", "~> 1.4.1")


### PR DESCRIPTION
en local j'avais `cannot load such file -- rack/server` quand je lancais `make docs-server`. je pense que c'est parce que la gem `yard` n'etait pas installée. 

je l'ai rajoutée en dépendance de la gem + j'ai modifié le makefile pour passer par bundle

j'ai aussi rajouté `.yardoc` au gitignore meme si je ne suis pas sur de moi, je ne sais pas si on est censé le publier ou non