### PR TITLE
config rubocop to prevent shorthand hash syntax for ruby 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ require:
 
 AllCops:
   NewCops: enable
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never # for ruby 3.0 support


### PR DESCRIPTION
cf https://rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax