### PR TITLE
prevent gh action from deploying guide on PRs

### DIFF
--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 jobs:
   rspec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
c'etait une erreur de ma part il ne faut pas deployer le guide quand on fait des PRs 🤦 