### PR TITLE
guide: add a DSFR-friendly colourscheme for the code snippets

### DIFF
--- a/guide/content/stylesheets/components/_highlight.scss
+++ b/guide/content/stylesheets/components/_highlight.scss
@@ -1,108 +1,56 @@
-$orange: darken(#f47738, 20%);
-$blue: #1d70b8;
-$dark-blue: #003078;
-$pink: darken(#d53880, 10%);
-$text: #0b0c0c;
-$green: #00703c;
-$light-grey: #f3f2f1;
-$light-pink: lighten(#f499be, 20%);
-$red: #d4351c;
-$dark-green: #365e07;
+$functions-color: var(--text-active-blue-france);
+$names-color: var(--text-label-blue-cumulus);
+$strings-color: var(--text-label-red-marianne);
+$text-color: var(--text-active-grey);
+$pseudo-keywords-color: var(--text-label-green-emeraude);
+$comments-color: var(--text-default-grey);
+$constants-color: var(--text-action-high-green-menthe);
 
-pre>code {
-  &.highlight {
-    color: $text;
+pre.highlight {
+  background: var(--background-default-grey);
+  color: $text-color;
 
-    .s,
-    .s1,
-    .s2,
-    .vi,
-    .sx {
-      color: $pink;
-    }
-
-    .nt,
-    .nf,
-    .nc {
-      color: $orange;
-    }
-
-    .n,
-    .p,
-    .k,
-    .mi,
-    .n,
-    .o,
-    .na,
-    .ss {
-      color: $dark-blue;
-    }
-
-    .k {
-      font-weight: 600;
-    }
-
-    .no {
-      color: #0e5e5e;
-    }
-
-    .kp {
-      color: $green;
-    }
-
-    // comments
-    .c,
-    .c1 {
-      color: $dark-green;
-      font-style: italic;
-    }
+  .s,
+  .s1,
+  .s2,
+  .vi,
+  .sx {
+    color: $strings-color;
   }
-}
 
+  .nt,
+  .nf,
+  .nc {
+    color: $functions-color;
+  }
 
-html[data-fr-theme=dark] {
-  pre>code {
-    &.highlight {
-      color: invert($text);
+  .n,
+  .p,
+  .k,
+  .mi,
+  .n,
+  .o,
+  .na,
+  .ss {
+    color: $names-color;
+  }
 
-      .s,
-      .s1,
-      .s2,
-      .vi,
-      .sx {
-        color: invert($pink);
-      }
+  .k {
+    font-weight: 600;
+  }
 
-      .nt,
-      .nf,
-      .nc {
-        color: invert($orange);
-      }
+  .no {
+    color: $constants-color;
+  }
 
-      .n,
-      .p,
-      .k,
-      .mi,
-      .n,
-      .o,
-      .na,
-      .ss {
-        color: invert($dark-blue);
-      }
+  .kp {
+    color: $pseudo-keywords-color;
+  }
 
-      .no {
-        color: invert(#0e5e5e);
-      }
-
-      .kp {
-        color: invert($green);
-      }
-
-      // comments
-      .c,
-      .c1 {
-        color: invert($dark-green);
-      }
-    }
+  // comments
+  .c,
+  .c1 {
+    color: $comments-color;
+    font-style: italic;
   }
 }

--- a/guide/layouts/default.slim
+++ b/guide/layouts/default.slim
@@ -1,5 +1,5 @@
 doctype html
-html lang="fr" data-fr-scheme=""
+html lang="fr" data-fr-scheme="system"
   == render '/partials/head.*'
   body
     == render '/partials/header.*'

--- a/guide/layouts/partials/example.slim
+++ b/guide/layouts/partials/example.slim
@@ -23,18 +23,18 @@ figure.app-example
 
     .fr-tabs__panel.fr-tabs__panel--selected tabindex="0" id=%(input-slim-#{anchor_id(caption)}) role="tabpanel" aria-labelledby=%(input-slim-#{anchor_id(caption)})
       pre.highlight
-        code.highlight.language-slim
+        code.language-slim
           | #{code}
 
     .fr-tabs__panel.fr-tabs__panel--hidden id=%(input-erb-#{anchor_id(caption)})
       pre.highlight
-        code.highlight.language-erb.wrap
+        code.language-erb.wrap
           = format_erb(code)
 
   - if defined?(data)
     .fr-tabs__panel.fr-tabs__panel--hidden id=%(input-data-#{anchor_id(caption)})
       pre.highlight
-        code.highlight.language-ruby.wrap
+        code.language-ruby.wrap
           = data
 
   - if defined?(render_in_boxes) && render_in_boxes
@@ -48,7 +48,7 @@ figure.app-example
     h4 Rendu HTML
 
     pre.highlight
-      code.highlight.language-html
+      code.language-html
         - if defined?(data)
           = format_slim(code, data)
         - else
@@ -77,7 +77,7 @@ figure.app-example
 
         .fr-tabs__panel role="tabpanel" aria-labelledby=%(output-html-#{anchor_id(caption)}) id=%(output-html-#{anchor_id(caption)})
           pre.highlight
-            code.highlight.language-html
+            code.language-html
               - if defined?(data)
                 = format_slim(code, data)
               - else

--- a/guide/layouts/partials/example.slim
+++ b/guide/layouts/partials/example.slim
@@ -22,18 +22,18 @@ figure.app-example
             | Data
 
     .fr-tabs__panel.fr-tabs__panel--selected tabindex="0" id=%(input-slim-#{anchor_id(caption)}) role="tabpanel" aria-labelledby=%(input-slim-#{anchor_id(caption)})
-      pre
+      pre.highlight
         code.highlight.language-slim
           | #{code}
 
     .fr-tabs__panel.fr-tabs__panel--hidden id=%(input-erb-#{anchor_id(caption)})
-      pre
+      pre.highlight
         code.highlight.language-erb.wrap
           = format_erb(code)
 
   - if defined?(data)
     .fr-tabs__panel.fr-tabs__panel--hidden id=%(input-data-#{anchor_id(caption)})
-      pre
+      pre.highlight
         code.highlight.language-ruby.wrap
           = data
 
@@ -47,7 +47,7 @@ figure.app-example
 
     h4 Rendu HTML
 
-    pre
+    pre.highlight
       code.highlight.language-html
         - if defined?(data)
           = format_slim(code, data)
@@ -76,7 +76,7 @@ figure.app-example
               == format_slim(code)
 
         .fr-tabs__panel role="tabpanel" aria-labelledby=%(output-html-#{anchor_id(caption)}) id=%(output-html-#{anchor_id(caption)})
-          pre
+          pre.highlight
             code.highlight.language-html
               - if defined?(data)
                 = format_slim(code, data)


### PR DESCRIPTION
The DSFR has a bunch of CSS variables for colours that will adapt to both light and dark themes.

Also update the example layout to match rouge's default output (it's pre.highlight, not pre > code.highlight)

## Light 

![image](https://user-images.githubusercontent.com/107635/207640991-92e425df-14f0-4f35-99f7-3398be8eb80e.png)

## Dark
![image](https://user-images.githubusercontent.com/107635/207641101-c1e5dbc1-02ff-4aac-b074-927ae4d42b4b.png)



## After
