### PR TITLE
Fix/allow haml

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,0 +1,7 @@
+skip_frontmatter: true
+
+linters:
+  LineLength:
+    max: 100
+  SpaceInsideHashAttributes:
+    style: no_space

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,15 @@ nanoc_default_port=3005
 nanoc_internal_checks=internal_links stale mixed_content
 nanoc_external_checks=external_links
 
-check: ruby-lint slim-lint rspec nanoc-check
+check: ruby-lint slim-lint haml-lint rspec nanoc-check
 nanoc-check: nanoc-check-all
 
 ruby-lint:
 	${prefix} rubocop lib spec guide/lib util
 slim-lint:
 	${prefix} slim-lint guide
+haml-lint:
+	${prefix} haml-lint guide
 rspec:
 	${prefix} rspec --format progress
 npm-install:

--- a/dsfr-view-components.gemspec
+++ b/dsfr-view-components.gemspec
@@ -59,6 +59,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("sassc", "~> 2.4.0")
   spec.add_development_dependency("slim", "~> 4.1.0")
   spec.add_development_dependency("slim_lint", "~> 0.22.0")
+  spec.add_development_dependency("haml", "~> 5.2.1")
+  spec.add_development_dependency("haml_lint")
   spec.add_development_dependency("webrick", "~> 1.7.0")
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/guide/Rules
+++ b/guide/Rules
@@ -9,7 +9,16 @@ compile '/**/*.slim' do
   filter :slim, format: :html
   filter :colorize_syntax, default_colorizer: :rouge
   filter :rubypants
-  layout '/default.*'
+  layout '/default.slim'
+  filter :relativize_paths, type: :html5
+  write item.identifier.without_ext + '/index.html'
+end
+
+compile '/**/*.haml' do
+  filter :haml
+  filter :colorize_syntax, default_colorizer: :rouge
+  filter :rubypants
+  layout '/default.haml'
   filter :relativize_paths, type: :html5
   write item.identifier.without_ext + '/index.html'
 end
@@ -33,4 +42,5 @@ compile '/**/*' do
   write item.identifier.to_s
 end
 
+layout '/**/*.haml', :haml
 layout '/**/*', :slim

--- a/guide/content/components/accordion.slim
+++ b/guide/content/components/accordion.slim
@@ -4,13 +4,13 @@ title: Accordéon
 
 p Les accordéons permettent aux utilisateurs d'afficher et de masquer des sections de contenu présentés dans une page.
 
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Accordéon section unique",
   code: accordion_single) do
   markdown:
     Vous pouvez aussi utiliser le helper `dsfr_accordion` avec une unique section. La section sera alors wrappée par une div `fr-accordions-group` invisible.
 
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Accordéon avec trois sections",
   code: accordion_normal) do
   markdown:

--- a/guide/content/components/alert.slim
+++ b/guide/content/components/alert.slim
@@ -5,21 +5,21 @@ title: Alerte
 p Les alertes permettent d’attirer l’attention de l’utilisateur sur une information sans interrompre sa tâche en cours.
 p Il existe deux tailles d'alertes : MD (par défaut) et SM. En taille MD l'alerte doit avoir un titre et peut avoir un contenu. En taille SM l'alerte ne peut pas avoir de titre et doit avoir un contenu.
 
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Alerte MD de succès avec du contenu",
   code: alert_md_success_with_content) do
 
   markdown:
     Une alerte a un `type` obligatoire parmi `:error`, `:success`, `:info` ou `:warning`.
 
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Alerte MD de succès sans contenu",
   code: alert_md_success_without_content) do
 
   markdown:
     En taille MD, le titre `title` est obligatoire pour les alertes mais le contenu est optionnel.
 
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Alerte d'erreur taille SM sans contenu",
   code: alert_sm_error) do
 
@@ -28,7 +28,7 @@ p Il existe deux tailles d'alertes : MD (par défaut) et SM. En taille MD l'aler
 
     A l'inverse, en taille SM il ne peut pas y avoir de titre mais le contenu est obligatoire.
 
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Alerte avec un bouton pour fermer",
   code: alert_md_with_close_button)
 

--- a/guide/content/helpers/link.haml
+++ b/guide/content/helpers/link.haml
@@ -3,7 +3,7 @@ title: Liens
 ---
 
 .fr-text-wrap
-  markdown:
+  :markdown
     Le DSFR distingue plusieurs types de liens selon leur cible ou le
     contexte où ils se trouvent :
 
@@ -17,24 +17,19 @@ title: Liens
     de passer par les helpers fournis par notre librairie. Voir le
     premier exemple ci-dessous.
 
-p
-  ' Les helpers fournis pour les liens suivent la signature du
-  == link_to('link_to de Rails',
-  'https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to',
-  { target: '_blank', rel: 'noopener' })
-  | .
+%p
+  Les helpers fournis pour les liens suivent la signature du
+  = link_to('link_to de Rails', rails_docs_url_helper, { target: '_blank', rel: 'noopener' })
+  \.
 
-== render('/partials/example.*',
-  caption: "Vue d'ensemble",
-  code: all_links) do
-  markdown:
+= render('/partials/example.haml', caption: "Vue d'ensemble", code: all_links) do
+  :markdown
     Quelques combinaisons (au fil du texte/interne,
     hors-texte/externe, etc.) sont exposées ici.
 
-== render('/partials/example.*',
-  caption: "Lien au fil du texte",
-  code: link_embed) do
-  markdown:
+
+= render('/partials/example.*', caption: "Lien au fil du texte", code: link_embed) do
+  :markdown
     Liens sans attributs particuliers, au fil du texte. Ils n'ont pas
     besoin d'une classe CSS particulière et sont automatiquement récupérés
     par le DSFR, ce qui explique pourquoi on emploie simplement le
@@ -42,10 +37,8 @@ p
 
     Ils peuvent être internes ou externes.
 
-== render('/partials/example.*',
-  caption: "Lien hors-texte",
-  code: link_simple) do
-  markdown:
+= render('/partials/example.*', caption: "Lien hors-texte", code: link_simple) do
+  :markdown
     Liens hors-texte, indépendants, aussi appellés liens simples par
     le DSFR. Ils sont identifiés par la classe `.fr-link` et on
     préférera donc `dsfr_link_to` dans ce cas-là.
@@ -57,13 +50,14 @@ p
     liens internes ; les liens externes sont déjà marqués par une
     icône donc il est fortement décommandé d'en faire usage sur eux.
 
-  p
-    ' Vous pouvez consulter
-    == link_to('la liste des icônes sur le site du DSFR', 'https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icones/', target: '_blank', rel: 'noopener')
-    | .
+  %p
+    Vous pouvez consulter la
+    = link_to('liste des icônes sur le site du DSFR',
+              dsfr_icon_list_link,
+              target: '_blank',
+              rel: 'noopener')
+    \.
 
-  markdown:
+  :markdown
     Enfin vous pouvez aussi jouer de trois tailles différentes pour
     vos liens : `sm`, `md` (par défaut) et `lg`.
-
-== render('/partials/related-info.*', links: link_info)

--- a/guide/content/introduction/options.slim
+++ b/guide/content/introduction/options.slim
@@ -10,7 +10,7 @@ markdown:
 
   Ces paramètres fonctionnent de la même manière pour tous les composants et slots.
 
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Alert avec des classes CSS spécifiques",
   code: alert_with_classes) do
 
@@ -20,7 +20,7 @@ markdown:
     Les classes CSS peuvent être passées sous forme de tableau ou en chaîne de caractères séparée par des espaces.
 
 markdown:
-== render('/partials/example.*',
+== render('/partials/example.slim',
   caption: "Inset text avec des attributs HTML spécifiques",
   code: alert_with_html_attributes) do
 

--- a/guide/content/stylesheets/_highlight.scss
+++ b/guide/content/stylesheets/_highlight.scss
@@ -7,7 +7,9 @@ $comments-color: var(--text-default-grey);
 $constants-color: var(--text-action-high-green-menthe);
 
 pre.highlight {
-  background: var(--background-default-grey);
+  background: var(--background-alt-grey);
+  padding: 1rem;
+  font-size: 0.9rem;
   color: $text-color;
 
   .s,

--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -2,8 +2,8 @@
 @import "dsfr/dist/dsfr.min";
 @import "dsfr/dist/utility/utility.min";
 
-// Applicaton components
-@import "components/highlight";
+// code CSS
+@import "highlight";
 
 figure {
   padding: 0;
@@ -14,7 +14,6 @@ figure {
   max-width: 42rem;
 }
 
-// we want a background for inline code samples (within text)
 code {
   background: var(--background-alt-grey);
   font-size: 0.9rem;

--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -16,10 +16,6 @@ figure {
 
 // we want a background for inline code samples (within text)
 code {
-  background: var(--background-default-grey-active);
-}
-
-// but not the actual code snippets
-pre > code {
-  background: initial;
+  background: var(--background-alt-grey);
+  font-size: 0.9rem;
 }

--- a/guide/layouts/default.haml
+++ b/guide/layouts/default.haml
@@ -1,0 +1,12 @@
+!!! 5
+%html{lang: "fr", "data-fr-scheme": "system"}
+  = render '/partials/head.slim'
+  %body
+    = render '/partials/header.slim'
+    %main#contenu{role: "main"}
+      .fr-container
+        = render '/partials/breadcrumbs.slim'
+        - if item
+          %h1= item[:title]
+        = yield
+    = render '/partials/footer.slim'

--- a/guide/layouts/default.slim
+++ b/guide/layouts/default.slim
@@ -1,12 +1,12 @@
 doctype html
 html lang="fr" data-fr-scheme="system"
-  == render '/partials/head.*'
+  == render '/partials/head.slim'
   body
-    == render '/partials/header.*'
+    == render '/partials/header.slim'
     main#contenu role="main"
       .fr-container
-        == render '/partials/breadcrumbs.*'
+        == render '/partials/breadcrumbs.slim'
         - if item
           h1= item[:title]
         == yield
-    == render '/partials/footer.*'
+    == render '/partials/footer.slim'

--- a/guide/layouts/partials/example.haml
+++ b/guide/layouts/partials/example.haml
@@ -1,0 +1,58 @@
+%h3.fr-mt-8w{id: anchor_id(caption)}
+  = link_to caption, "#".concat(anchor_id(caption)), class: "header-anchor"
+
+.fr-text-wrap
+  - if block_given? && (content = yield)
+    = content
+
+%figure.app-example
+  %h4 Code
+
+  %pre.highlight
+    %code.language-haml
+      &= code
+
+  %h4 Résultat
+  .fr-tabs
+    %ul.fr-tabs__list{role: "tablist"}
+      %li{role: "presentation"}
+        %button.fr-tabs__tab{
+          id: "output-rendered-#{anchor_id(caption)}",
+          tabindex: "0",
+          aria: {
+            selected: "true",
+            controls: "output-rendered-#{anchor_id(caption)}"
+          },
+          role: "tab"
+        }
+          Rendu
+      %li{role: "presentation"}
+        %button.fr-tabs__tab{
+          id: "output-html-#{anchor_id(caption)}",
+          tabindex: "0",
+          aria: {
+            selected: "false",
+            controls: "output-html-#{anchor_id(caption)}"
+          },
+          role: "tab"
+        }
+          HTML
+
+    .fr-tabs__panel.fr-tabs__panel--selected{
+      role: "tabpanel",
+      "aria-labelledby" => "output-rendered-#{anchor_id(caption)}",
+      id: "output-rendered-#{anchor_id(caption)}"
+    }
+      = format_haml(code)
+
+    .fr-tabs__panel{
+      role: "tabpanel",
+      "aria-labelledby" => "output-html-#{anchor_id(caption)}",
+      id: "output-html-#{anchor_id(caption)}"
+    }
+      %pre.highlight
+        %code.language-html
+          - if defined?(data)
+            Some HTML
+          - else
+            &= format_haml(code)

--- a/guide/layouts/partials/theme-modal.html.erb
+++ b/guide/layouts/partials/theme-modal.html.erb
@@ -1,4 +1,3 @@
-<%# copied from https://template.incubateur.net/ %>
 <dialog id="fr-theme-modal" class="fr-modal" role="dialog" aria-labelledby="fr-theme-modal-title">
   <div class="fr-container fr-container--fluid fr-container-md">
     <div class="fr-grid-row fr-grid-row--center">

--- a/guide/lib/examples/link_helpers.rb
+++ b/guide/lib/examples/link_helpers.rb
@@ -2,38 +2,38 @@ module Examples
   module LinkHelpers
     def link_embed
       <<~LINK
-        p
-          ' Rendez-vous sur
+        %p
+          Rendez-vous sur
           = link_to("cette page", "#")
-          | pour en apprendre plus.
+          pour en apprendre plus.
 
-        p
-          ' Rendez-vous sur
+        %p
+          Rendez-vous sur
           = link_to("cet autre site web", "#", target: "_blank", rel: "noopener")
-          | pour en apprendre toujours plus.
+          pour en apprendre toujours plus.
       LINK
     end
 
     def link_simple
       <<~LINK
-        p= dsfr_link_to("Lien simple", "#")
-        p= dsfr_link_to("Lien simple externe", "#", target: "_blank", rel: "noopener")
-        p= dsfr_link_to("Lien simple avec icône à droite", "#", icon_right: "account-fill")
-        p= dsfr_link_to("Lien taille petite", "#", size: "sm")
-        p= dsfr_link_to("Lien taille large", "#", size: "lg")
+        %p= dsfr_link_to("Lien simple", "#")
+        %p= dsfr_link_to("Lien simple externe", "#", target: "_blank", rel: "noopener")
+        %p= dsfr_link_to("Lien simple avec icône à droite", "#", icon_right: "account-fill")
+        %p= dsfr_link_to("Lien taille petite", "#", size: "sm")
+        %p= dsfr_link_to("Lien taille large", "#", size: "lg")
       LINK
     end
 
     def all_links
       <<~LINK
-        p
-          ' Ceci est un
+        %p
+          Ceci est un
           = link_to "lien au fil du texte", "#"
-          | . Ceci est un
+          \\. Ceci est un
           = link_to "lien externe au fil du texte", "#", { target: "_blank", rel: "noopener" }
-          | .
-        p= dsfr_link_to "Ceci est un lien hors-texte.", "#"
-        p= dsfr_link_to "Ceci est un lien externe, hors-texte.", "#", { target: "_blank", rel: "noopener" }
+          \\.
+        %p= dsfr_link_to "Ceci est un lien hors-texte.", "#"
+        %p= dsfr_link_to "Ceci est un lien externe, hors-texte.", "#", { target: "_blank", rel: "noopener" }
       LINK
     end
   end

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -22,6 +22,22 @@ module Helpers
       block.call
     end
 
+    # NOTE: this is copied over from the format_slim method below
+    def format_haml(raw, data = nil)
+      # FIXME: not sure why when we're several
+      #        blocks deep we need to unescape more
+      #        than once
+      locals = if data
+                 eval(data)
+               else
+                 {}
+               end
+
+      template = Haml::Engine.new(raw).render(FakeView.new, **locals)
+
+      CGI.unescapeHTML(template)
+    end
+
     def format_slim(raw, data = nil)
       # FIXME: not sure why when we're several
       #        blocks deep we need to unescape more

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -33,16 +33,16 @@ module Helpers
       # 'https://codeclimate.com/github/DFE-Digital/govuk-components'
     end
 
-    def dfe_rails_boilerplate_link
-      # 'https://github.com/DFE-Digital/govuk-rails-boilerplate'
-    end
-
     def viewcomponent_link
       'https://viewcomponent.org/'
     end
 
     def rails_docs_url_helper
       'https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html'
+    end
+
+    def dsfr_icon_list_link
+      'https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icones/'
     end
 
     def rails_docs_button_to

--- a/guide/nanoc.yaml
+++ b/guide/nanoc.yaml
@@ -1,7 +1,7 @@
 # A list of file extensions that Nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file
 # will be considered as binary.
-text_extensions: ['slim', 'js', 'css', 'sass', 'scss', 'erb', 'html', 'md', 'xml']
+text_extensions: ['slim', 'haml', 'js', 'css', 'sass', 'scss', 'erb', 'html', 'md', 'xml']
 
 prune:
   auto_prune: true


### PR DESCRIPTION
This does roughly two things:

1. enables HAML to be processed with the right gems/rules
2. make a HAML equivalent of every Slim partial that uses `yield` since you can't mix&match render blocks.

I had more templates ported over (footer, header, head, breadcrumbs) but let's do it progressively.

AND! some cheeky CSS adjustements for our code snippets:

<img width="939" alt="Capture d’écran 2022-12-21 à 16 29 58" src="https://user-images.githubusercontent.com/107635/208942018-72e0eb10-c39f-4019-ac41-a0b5890107f1.png">
