### PR TITLE
use optimistic constraints for gem dependencies view_component and pagy

### DIFF
--- a/dsfr-view-components.gemspec
+++ b/dsfr-view-components.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency("html-attributes-utils", "~> 0.9", ">= 0.9.2")
-  spec.add_dependency("pagy", "~> 5.10.1")
-  spec.add_dependency "view_component", "~> 2.74.1"
+  spec.add_dependency("pagy", ">= 5.10.1")
+  spec.add_dependency "view_component", ">= 2.74.1"
 
   spec.add_development_dependency "deep_merge"
   spec.add_development_dependency "guard"
@@ -50,6 +50,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard"
 
   # Required for the guide
+  spec.add_development_dependency("haml", "~> 6.1.1")
+  spec.add_development_dependency("haml_lint")
   spec.add_development_dependency("htmlbeautifier", "~> 1.4.1")
   spec.add_development_dependency("kramdown", "~> 2.4.0")
   spec.add_development_dependency("nanoc", "~> 4.11")
@@ -59,8 +61,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("sassc", "~> 2.4.0")
   spec.add_development_dependency("slim", "~> 4.1.0")
   spec.add_development_dependency("slim_lint", "~> 0.22.0")
-  spec.add_development_dependency("haml", "~> 6.1.1")
-  spec.add_development_dependency("haml_lint")
   spec.add_development_dependency("webrick", "~> 1.7.0")
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
- `view_component` is now on 2.80
- `pagy` is now on `6+` but I think it's safe because we don't actually use it yet in the implemented components so we can make sure it works with 6 when we'll implement them

note that my rubocop re-orders the gems , we're still on different behaviour for some mysterious reason 🤷 