### PR TITLE
upgrade view_component, pagy 6, and html-attributes-utils 1

### DIFF
--- a/dsfr-view-components.gemspec
+++ b/dsfr-view-components.gemspec
@@ -32,9 +32,9 @@ Gem::Specification.new do |spec|
     spec.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end
 
-  spec.add_dependency("html-attributes-utils", "~> 0.9", ">= 0.9.2")
-  spec.add_dependency("pagy", "~> 5.10.1")
-  spec.add_dependency "view_component", "~> 2.74.1"
+  spec.add_dependency "html-attributes-utils", "~> 1"
+  spec.add_dependency "pagy", "~> 6"
+  spec.add_dependency "view_component", "~> 2"
 
   spec.add_development_dependency "deep_merge"
   spec.add_development_dependency "guard"
@@ -50,6 +50,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard"
 
   # Required for the guide
+  spec.add_development_dependency("haml", "~> 6.1.1")
+  spec.add_development_dependency("haml_lint")
   spec.add_development_dependency("htmlbeautifier", "~> 1.4.1")
   spec.add_development_dependency("kramdown", "~> 2.4.0")
   spec.add_development_dependency("nanoc", "~> 4.11")
@@ -59,8 +61,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("sassc", "~> 2.4.0")
   spec.add_development_dependency("slim", "~> 4.1.0")
   spec.add_development_dependency("slim_lint", "~> 0.22.0")
-  spec.add_development_dependency("haml", "~> 6.1.1")
-  spec.add_development_dependency("haml_lint")
   spec.add_development_dependency("webrick", "~> 1.7.0")
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -22,6 +22,11 @@ $LOAD_PATH.unshift(File.expand_path("../../lib", "lib"))
 
 require 'dsfr/components'
 
+# FIXME
+# cf https://github.com/DFE-Digital/govuk-components/commit/a77dd4d55fb7a4afc7d2911174e62dbe4da08545
+# cf https://github.com/ViewComponent/view_component/issues/1565
+ViewComponent::Base.config.view_component_path = "app/components"
+
 require 'components/dsfr_component'
 require 'components/dsfr_component/traits'
 require 'components/dsfr_component/traits/custom_html_attributes'


### PR DESCRIPTION
I set pessimistic constraints on all 3 dependencies with only the major version number so that by default updates patches and minor updates will be considered safe in the future.

major version upgrades : 
- `html-attributes-utils` : 0 -> 1
- `pagy`: 5 -> 6

minor version upgrade for `view_component` to 2.80

I had to backport a patch from govuk-components for the view_component upgrade