### PR TITLE
refactor: deduplicate helper to class name mapping

### DIFF
--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -1,13 +1,14 @@
 # rubocop:disable Style/TrailingCommaInHashLiteral
 module DsfrComponentsHelper
-  {
+  HELPER_NAME_TO_CLASS_NAME = {
     dsfr_alert: 'DsfrComponent::AlertComponent',
     dsfr_accordion: 'DsfrComponent::AccordionComponent',
     dsfr_accordion_section: 'DsfrComponent::AccordionComponent::SectionComponent',
     dsfr_tile: 'DsfrComponent::TileComponent',
     dsfr_badge: 'DsfrComponent::BadgeComponent',
     # DO NOT REMOVE: new component mapping here
-  }.each do |name, klass|
+  }.freeze
+  HELPER_NAME_TO_CLASS_NAME.each do |name, klass|
     define_method(name) do |*args, **kwargs, &block|
       capture do
         render(klass.constantize.new(*args, **kwargs)) do |com|

--- a/guide/content/introduction/utilisation.haml
+++ b/guide/content/introduction/utilisation.haml
@@ -35,7 +35,7 @@ title: Utilisation
         %th Composant
         %th Helper
     %tbody
-      - component_helper_mapping.each do |class_name, helper_method|
+      - DsfrComponentsHelper::HELPER_NAME_TO_CLASS_NAME.each do |helper_method, class_name|
         %tr
           %td
             %code= class_name

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -26,15 +26,6 @@ module Helpers
       dsfr_component_doc_link("Tuile")
     end
 
-    def component_helper_mapping
-      {
-        "DsfrComponent::AlertComponent" => "dsfr_alert",
-        "DsfrComponent::AccordionComponent" => "dsfr_accordion",
-        "DsfrComponent::TileComponent" => "dsfr_tile",
-        "DsfrComponent::Badge" => "dsfr_badge"
-      }
-    end
-
     def badge_info
       dsfr_component_doc_link("Badge")
     end


### PR DESCRIPTION
il y avait deux hashes de mapping entre helper names et component class names, un dans le guide et un dans la gem.
je supprime celui du guide pour n'utiliser que celui de la gem