### PR TITLE
refactor: inline single-use guide helpers

### DIFF
--- a/guide/content/components/accordion.haml
+++ b/guide/content/components/accordion.haml
@@ -21,4 +21,4 @@ title: Accordéon
     L'attribut `id` est optionnel et permet de définir une ancre HTML réutilisable.
     S'il n'est pas passé un `id` aléatoire sera généré.
 
-= render('/partials/related-info.haml', links: accordion_info)
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("Accordéons", "accordeon"))

--- a/guide/content/components/alert.haml
+++ b/guide/content/components/alert.haml
@@ -36,4 +36,4 @@ title: Alerte
   caption: "Alerte avec un bouton pour fermer",
   code: alert_md_with_close_button)
 
-= render('/partials/related-info.haml', links: alert_info)
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("Alerte"))

--- a/guide/content/components/badge.haml
+++ b/guide/content/components/badge.haml
@@ -18,4 +18,4 @@ title: Badge
 
 = render('/partials/example.haml', caption: "Vue d'ensemble", code: badge_default)
 
-= render('/partials/related-info.haml', links: badge_info)
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("Badge"))

--- a/guide/content/components/tile.haml
+++ b/guide/content/components/tile.haml
@@ -24,4 +24,4 @@ title: Tuile (Tile)
   Tuile horizontale avec image, titre et description
 
 .fr-mt-4w
-  = render('/partials/related-info.haml', links: tile_info)
+  = render('/partials/related-info.haml', links: dsfr_component_doc_link("Tuile"))

--- a/guide/layouts/partials/header.haml
+++ b/guide/layouts/partials/header.haml
@@ -19,6 +19,6 @@
           .fr-header__service
             %a{href: "/", title: "#{site_title} - Accueil"}
               %p.fr-header__service-title
-                = repository_name
+                DSFR-View-Components
             %p.fr-header__service-tagline
               = site_title

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -2,28 +2,8 @@ module Helpers
   module ContentHelpers
     DSFR_COMPONENT_DOC_HREF = "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/".freeze
 
-    def repository_name
-      "DSFR-View-Components"
-    end
-
     def site_title
       "Composants Rails ViewComponent pour le Système de Design de lʼÉtat"
-    end
-
-    def alert_info
-      dsfr_component_doc_link("Alerte")
-    end
-
-    def accordion_info
-      dsfr_component_doc_link("Accordéons", "accordeon")
-    end
-
-    def link_info
-      dsfr_component_doc_link("Liens")
-    end
-
-    def tile_info
-      dsfr_component_doc_link("Tuile")
     end
 
     def component_helper_mapping
@@ -33,10 +13,6 @@ module Helpers
         "DsfrComponent::TileComponent" => "dsfr_tile",
         "DsfrComponent::Badge" => "dsfr_badge"
       }
-    end
-
-    def badge_info
-      dsfr_component_doc_link("Badge")
     end
 
   private

--- a/lib/generators/dsfr_component/templates/component.haml.erb
+++ b/lib/generators/dsfr_component/templates/component.haml.erb
@@ -9,3 +9,5 @@ title: <%= name %>
 = render('/partials/example.haml', caption: "Vue d'ensemble", code: <%= file_name %>_default) do
   :markdown
     Le rendu de base du <%= name %>Component
+
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("<%= name %>"))


### PR DESCRIPTION
I have inlined the call to the `dsfr_component_doc_link` helper in the component haml guide pages. 

The `alert_info`, `badge_info` etc were only called once and with very simple values. I don't think there's a point in generizing them into full blown helpers. 

This also allows to add the link to the doc directly in the scaffold template.

I also removed the `repository_name` for the same single-usage reason. However I left the `site_title` one as it's used > 3 times.
