### PR TITLE
add title_tag param to tiles

### DIFF
--- a/app/components/dsfr_component/base.rb
+++ b/app/components/dsfr_component/base.rb
@@ -5,6 +5,8 @@ class DsfrComponent::Base < ViewComponent::Base
 
   delegate :config, to: Dsfr::Components
 
+  TITLE_TAGS = %i[h1 h2 h3 h4 h5 h6].freeze
+
   def initialize(classes:, html_attributes:)
     if classes.nil?
       Rails.logger.warn("classes is nil, if no custom classes are needed omit the param")

--- a/app/components/dsfr_component/base.rb
+++ b/app/components/dsfr_component/base.rb
@@ -5,7 +5,7 @@ class DsfrComponent::Base < ViewComponent::Base
 
   delegate :config, to: Dsfr::Components
 
-  TITLE_TAGS = %i[h1 h2 h3 h4 h5 h6].freeze
+  HEADING_LEVELS = [1, 2, 3, 4, 5, 6].freeze
 
   def initialize(classes:, html_attributes:)
     if classes.nil?

--- a/app/components/dsfr_component/tile_component.html.erb
+++ b/app/components/dsfr_component/tile_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(**html_attributes) do %>
   <div class="fr-tile__body">
-    <%= content_tag(title_tag, class: "fr-tile__title") do %>
+    <%= title_tag(class: "fr-tile__title") do %>
       <a class="fr-tile__link" href="<%= url %>">
       <%= title %>
       </a>

--- a/app/components/dsfr_component/tile_component.html.erb
+++ b/app/components/dsfr_component/tile_component.html.erb
@@ -1,10 +1,10 @@
 <%= tag.div(**html_attributes) do %>
   <div class="fr-tile__body">
-    <h4 class="fr-tile__title">
+    <%= content_tag(title_tag, class: "fr-tile__title") do %>
       <a class="fr-tile__link" href="<%= url %>">
       <%= title %>
       </a>
-    </h4>
+    <% end %>
     <% if description.present? %>
       <p class="fr-tile__desc">
         <%= description %>

--- a/app/components/dsfr_component/tile_component.rb
+++ b/app/components/dsfr_component/tile_component.rb
@@ -6,20 +6,24 @@ module DsfrComponent
     # @param image_alt [String] L'alternative de l'image. Doit a priori être vide si l'image est illustrative et n'apporte pas de valeur sémantique.
     # @param description [String] description (optional)
     # @param orientation [String] :horizontal or :vertical
-    def initialize(title:, url:, image_src: nil, image_alt: "", description: nil, orientation: :vertical, classes: [], html_attributes: {})
+    # @param title_tag [Symbol] :h1, :h2, :h3, :h4 (default), :h5, :h6
+    def initialize(title:, url:, image_src: nil, image_alt: "", description: nil, orientation: :vertical, title_tag: :h4, classes: [], html_attributes: {})
       @title = title
       @url = url
       @image_src = image_src
       @image_alt = image_alt
       @description = description
       @orientation = orientation
+      @title_tag = title_tag.to_sym
+
+      raise ArgumentError if TITLE_TAGS.exclude?(title_tag)
 
       super(classes: classes, html_attributes: html_attributes)
     end
 
   private
 
-    attr_reader :title, :url, :image_src, :image_alt, :description, :orientation
+    attr_reader :title, :url, :image_src, :image_alt, :description, :orientation, :title_tag
 
     def default_attributes
       k = %w[fr-tile fr-enlarge-link]

--- a/app/components/dsfr_component/tile_component.rb
+++ b/app/components/dsfr_component/tile_component.rb
@@ -6,29 +6,33 @@ module DsfrComponent
     # @param image_alt [String] L'alternative de l'image. Doit a priori être vide si l'image est illustrative et n'apporte pas de valeur sémantique.
     # @param description [String] description (optional)
     # @param orientation [String] :horizontal or :vertical
-    # @param title_tag [Symbol] :h1, :h2, :h3, :h4 (default), :h5, :h6
-    def initialize(title:, url:, image_src: nil, image_alt: "", description: nil, orientation: :vertical, title_tag: :h4, classes: [], html_attributes: {})
+    # @param heading_level [Integer] 1, 2, 3, 4 (default), 5, 6
+    def initialize(title:, url:, image_src: nil, image_alt: "", description: nil, orientation: :vertical, heading_level: 4, classes: [], html_attributes: {})
       @title = title
       @url = url
       @image_src = image_src
       @image_alt = image_alt
       @description = description
       @orientation = orientation
-      @title_tag = title_tag.to_sym
+      @heading_level = heading_level
 
-      raise ArgumentError if TITLE_TAGS.exclude?(title_tag)
+      raise ArgumentError if HEADING_LEVELS.exclude?(heading_level)
 
       super(classes: classes, html_attributes: html_attributes)
     end
 
   private
 
-    attr_reader :title, :url, :image_src, :image_alt, :description, :orientation, :title_tag
+    attr_reader :title, :url, :image_src, :image_alt, :description, :orientation, :heading_level
 
     def default_attributes
       k = %w[fr-tile fr-enlarge-link]
       k << "fr-tile--horizontal" if orientation.to_sym == :horizontal
       { class: k.join(" ") }
+    end
+
+    def title_tag(*args, **kwargs, &block)
+      content_tag("h#{heading_level}", *args, **kwargs, &block)
     end
   end
 end

--- a/app/components/dsfr_component/tile_component.rb
+++ b/app/components/dsfr_component/tile_component.rb
@@ -13,14 +13,13 @@ module DsfrComponent
       @image_alt = image_alt
       @description = description
       @orientation = orientation
-      @background = background
 
       super(classes: classes, html_attributes: html_attributes)
     end
 
   private
 
-    attr_reader :title, :url, :image_src, :image_alt, :description, :orientation, :background
+    attr_reader :title, :url, :image_src, :image_alt, :description, :orientation
 
     def default_attributes
       k = %w[fr-tile fr-enlarge-link]

--- a/guide/content/components/tile.haml
+++ b/guide/content/components/tile.haml
@@ -23,5 +23,10 @@ title: Tuile (Tile)
 = render('/partials/example.haml', caption: "Tuile horizontale", code: tile_horizontal) do
   Tuile horizontale avec image, titre et description
 
+= render('/partials/example.haml', caption: "Tuile avec un niveau de titre spécifique", code: tile_title_tag) do
+  L’argument `title_tag` ne change pas l’aspect de la tuile mais permet d’adapter le niveau du heading à votre page pour améliorer l’accessibilité en respectant la cohérence de niveaux de titres.
+
+  Le niveau par défaut est `h4`, vous pouvez l’augmenter ou le baisser selon votre contexte.
+
 .fr-mt-4w
   = render('/partials/related-info.haml', links: dsfr_component_doc_link("Tuile"))

--- a/guide/content/components/tile.haml
+++ b/guide/content/components/tile.haml
@@ -23,10 +23,11 @@ title: Tuile (Tile)
 = render('/partials/example.haml', caption: "Tuile horizontale", code: tile_horizontal) do
   Tuile horizontale avec image, titre et description
 
-= render('/partials/example.haml', caption: "Tuile avec un niveau de titre spécifique", code: tile_title_tag) do
-  L’argument `title_tag` ne change pas l’aspect de la tuile mais permet d’adapter le niveau du heading à votre page pour améliorer l’accessibilité en respectant la cohérence de niveaux de titres.
+= render('/partials/example.haml', caption: "Tuile avec un niveau de titre spécifique", code: tile_heading_level) do
+  :markdown
+    L’argument `heading_level` ne change pas l’aspect de la tuile mais permet d’adapter le niveau du heading à votre page pour améliorer l’accessibilité en respectant la cohérence de niveaux de titres.
 
-  Le niveau par défaut est `h4`, vous pouvez l’augmenter ou le baisser selon votre contexte.
+    Le niveau par défaut est `4`, vous pouvez l’augmenter ou le baisser selon votre contexte.
 
 .fr-mt-4w
   = render('/partials/related-info.haml', links: dsfr_component_doc_link("Tuile"))

--- a/guide/lib/examples/tile_helpers.rb
+++ b/guide/lib/examples/tile_helpers.rb
@@ -49,5 +49,16 @@ module Examples
                     html_attributes: {style: "max-width: 30rem;"})
       RAW
     end
+
+    def tile_title_tag
+      <<~RAW
+        = dsfr_tile(title: "Orgue de Fontainebleau",
+                    url: "#",
+                    image_src: "/assets/images/orgue.jpg",
+                    image_alt: "Orgue orange et bleu",
+                    title_tag: :h2,
+                    html_attributes: {style: "max-width: 20rem;"})
+      RAW
+    end
   end
 end

--- a/guide/lib/examples/tile_helpers.rb
+++ b/guide/lib/examples/tile_helpers.rb
@@ -50,13 +50,13 @@ module Examples
       RAW
     end
 
-    def tile_title_tag
+    def tile_heading_level
       <<~RAW
         = dsfr_tile(title: "Orgue de Fontainebleau",
                     url: "#",
                     image_src: "/assets/images/orgue.jpg",
                     image_alt: "Orgue orange et bleu",
-                    title_tag: :h2,
+                    heading_level: 2,
                     html_attributes: {style: "max-width: 20rem;"})
       RAW
     end

--- a/spec/components/dsfr_component/tile_component_spec.rb
+++ b/spec/components/dsfr_component/tile_component_spec.rb
@@ -56,4 +56,16 @@ RSpec.describe(DsfrComponent::TileComponent, type: :component) do
       expect(rendered_content).to have_tag('div', with: { class: "fr-tile fr-enlarge-link fr-tile--horizontal" })
     end
   end
+
+  context 'with specific title_level' do
+    let(:args) { { url: "/path", title: 'Titre', title_tag: :h2 } }
+
+    specify 'renders correctly' do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-tile fr-enlarge-link" }) do
+        with_tag('div', with: { class: 'fr-tile__body' }) do
+          with_tag("h2", with: { class: "fr-tile__title" })
+        end
+      end
+    end
+  end
 end

--- a/spec/components/dsfr_component/tile_component_spec.rb
+++ b/spec/components/dsfr_component/tile_component_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe(DsfrComponent::TileComponent, type: :component) do
   end
 
   context 'with specific title_level' do
-    let(:args) { { url: "/path", title: 'Titre', title_tag: :h2 } }
+    let(:args) { { url: "/path", title: 'Titre', heading_level: 2 } }
 
     specify 'renders correctly' do
       expect(rendered_content).to have_tag('div', with: { class: "fr-tile fr-enlarge-link" }) do


### PR DESCRIPTION
Some DSFR components use titles, such as the `Tile` which uses a `h4`. The level of this heading seems arbitrary in the DSFR examples and does not impact its aspect. However it’s a problem for accessibility : heading levels are supposed to be coherent, you should not follow an `h1` with an `h4` for example. cf [this aXe rule](https://dequeuniversity.com/rules/axe/4.6/heading-order?application=axeAPI) and [RGAA 9.1](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9.1).

In this PR I introduce a `title_tag` param specific to the `TileComponent`. The pattern will probably be reused in other components, so it makes sense to take some time to consider this param name. I thought about `title_level` or `heading_level` but I feel it’s more explicit to pass `:h3` than `3` as an argument. Maybe `heading_tag` would be a better name though. 

There is a small incoherence with the `_tag` suffix : in the templates we have to call `content_tag(title_tag, "blah")` which makes little sense : `content_tag` is a HTML helper whereas `title_tag` will only return `h2`.

@freesteph if you have smart ideas I'm all ears :) 

<img width="737" alt="Screenshot 2023-02-17 at 17 44 51" src="https://user-images.githubusercontent.com/883348/219714894-9729ce7c-f2e3-454f-b18f-c2ac564639d7.png">

this will unblock https://github.com/betagouv/collectif-objets/pull/706

cf https://mattermost.incubateur.net/betagouv/pl/4pxd4u6gwbb5per8pb153yezhe