### PR TITLE
component: modal

### DIFF
--- a/app/components/dsfr_component/modal_component.html.erb
+++ b/app/components/dsfr_component/modal_component.html.erb
@@ -1,0 +1,26 @@
+<%= tag.dialog(**html_attributes) do %>
+  <div class="fr-container fr-container--fluid fr-container-md">
+    <div class="fr-grid-row fr-grid-row--center">
+      <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+        <div class="fr-modal__body">
+          <div class="fr-modal__header">
+            <button class="fr-link--close fr-link" aria-controls="<%= id %>" type="button">Fermer</button>
+          </div>
+          <div class="fr-modal__content">
+            <%= content_tag(:h1, title, class: "fr-modal__title", id: title_id) %>
+            <%= content %>
+          </div>
+          <% if buttons? %>
+            <div class="fr-modal__footer">
+              <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                <% buttons.each do |button| %>
+                  <%= button %>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/components/dsfr_component/modal_component.html.erb
+++ b/app/components/dsfr_component/modal_component.html.erb
@@ -4,7 +4,11 @@
       <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
         <div class="fr-modal__body">
           <div class="fr-modal__header">
-            <button class="fr-link--close fr-link" aria-controls="<%= id %>" type="button">Fermer</button>
+            <% if header? %>
+              <%= header %>
+            <% else %>
+              <button class="fr-link--close fr-link" aria-controls="<%= id %>" type="button">Fermer</button>
+            <% end %>
           </div>
           <div class="fr-modal__content">
             <%= content_tag(:h1, title, class: "fr-modal__title", id: title_id) %>

--- a/app/components/dsfr_component/modal_component.rb
+++ b/app/components/dsfr_component/modal_component.rb
@@ -1,0 +1,30 @@
+module DsfrComponent
+  class ModalComponent < DsfrComponent::Base
+    renders_many :buttons, ButtonComponent
+
+    # @param title [String] Titre de la modale
+    def initialize(title:, classes: [], html_attributes: {})
+      @title = title
+
+      @id = html_attributes[:id]
+      super(classes: classes, html_attributes: html_attributes)
+    end
+
+  private
+
+    attr_reader :title, :title_icon, :id
+
+    def default_attributes
+      {
+        class: "fr-modal",
+        role: "dialog",
+        id: @id,
+        "aria-labelledby": title_id
+      }.compact
+    end
+
+    def title_id
+      "#{@id}-title" if @id.present?
+    end
+  end
+end

--- a/app/components/dsfr_component/modal_component.rb
+++ b/app/components/dsfr_component/modal_component.rb
@@ -1,10 +1,13 @@
 module DsfrComponent
   class ModalComponent < DsfrComponent::Base
-    renders_many :buttons, ButtonComponent
+    renders_one :header
+    renders_many :buttons
 
     # @param title [String] Titre de la modale
-    def initialize(title:, classes: [], html_attributes: {})
+    # @param opened [Boolean] Ouvre la modale dès le chargement de la page
+    def initialize(title:, opened: false, classes: [], html_attributes: {})
       @title = title
+      @opened = opened
 
       @id = html_attributes[:id]
       super(classes: classes, html_attributes: html_attributes)
@@ -16,7 +19,7 @@ module DsfrComponent
 
     def default_attributes
       {
-        class: "fr-modal",
+        class: "fr-modal #{@opened ? 'fr-modal--opened' : ''}",
         role: "dialog",
         id: @id,
         "aria-labelledby": title_id

--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -9,6 +9,7 @@ module DsfrComponentsHelper
     dsfr_tag: 'DsfrComponent::TagComponent',
     dsfr_stepper: 'DsfrComponent::StepperComponent',
     dsfr_button: 'DsfrComponent::ButtonComponent',
+    dsfr_modal: 'DsfrComponent::ModalComponent',
     # DO NOT REMOVE: new component mapping here
   }.freeze
   HELPER_NAME_TO_CLASS_NAME.each do |name, klass|

--- a/guide/content/components/modal.haml
+++ b/guide/content/components/modal.haml
@@ -1,0 +1,31 @@
+---
+title: Modal
+---
+
+.fr-text-wrap
+  :markdown
+    La modale permet de concentrer l’attention de l’utilisateur exclusivement sur une tâche ou un élément d’information, sans perdre le contexte de la page en cours. Ce composant nécessite une action de l’utilisateur afin d'être clôturée ou ouverte.
+
+
+= render('/partials/example.haml', caption: "Modale simple", code: modal_default) do
+  :markdown
+    La modale par défaut permet de mettre en évidence une information qui ne nécessite pas d’action de l’utilisateur.
+
+    Les modales s’affichent suite à un clic sur un bouton qui possède l’attribut `aria-controls` correspondant à l’identifiant de la modale ET l’attribut `data-fr-opened` à `false`.
+
+= render('/partials/example.haml', caption: "Modale avec un bouton", code: modal_button) do
+  :markdown
+    La modale avec une zone d’action permet de guider l’utilisateur vers des actions attendues.
+
+    Dans ce cas, vous pouvez passer les arguments au composant Button directement.
+
+= render('/partials/example.haml', caption: "Modale avec deux boutons", code: modal_two_buttons) do
+  :markdown
+    Il peut aussi y avoir un groupe de boutons hiérarchisé.
+
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("Modale"))
+
+:css
+  .fr-tabs__panel {
+    min-height: 400px;
+  }

--- a/guide/content/components/modal.haml
+++ b/guide/content/components/modal.haml
@@ -23,6 +23,15 @@ title: Modal
   :markdown
     Il peut aussi y avoir un groupe de boutons hiérarchisé.
 
+= render('/partials/example.haml', caption: "Modale pré-ouverte pour Turbo Drive", code: modal_turbo) do
+  :markdown
+    La modale peut s’afficher ouverte dès le chargement de la page grace à l’option `opened: true`.
+    Cela permet notamment de rendre compatible cette modale avec un système comme Turbo Drive et de développer une application progressive, qui marchera avec ou sans JS.
+
+    Il faut pour cela bien penser que les boutons de fermetures natifs des modales ne fonctionneront pas dans ce cas (sans JS).
+    On peut donc par exemple utiliser des liens de navigation `dsfr_link_to` plutôt que des boutons.
+    De la même manière, il faut aussi bien penser à modifier le bouton du header par un lien en utilisant le slot `header`.
+
 = render('/partials/related-info.haml', links: dsfr_component_doc_link("Modale"))
 
 :css

--- a/guide/lib/examples/modal_helpers.rb
+++ b/guide/lib/examples/modal_helpers.rb
@@ -1,0 +1,68 @@
+module Examples
+  module ModalHelpers
+    def modal_default
+      <<~RAW
+        = dsfr_modal(title: "Information importante", html_attributes: { id: "modal-1" }) do |component|
+          %p Bonjour ceci est important
+        = dsfr_button(label: "Ouvrir la modale", html_attributes: { "data-fr-opened": false, "aria-controls": "modal-1" })
+      RAW
+    end
+
+    def modal_button
+      <<~RAW
+        = dsfr_modal(title: "Information importante", html_attributes: { id: "modal-2" }) do |component|
+          %p Bonjour ceci est important
+          - component.with_button(label: "Valider")
+        = dsfr_button(label: "Ouvrir la modale", html_attributes: { "data-fr-opened": false, "aria-controls": "modal-2" })
+      RAW
+    end
+
+    def modal_two_buttons
+      <<~RAW
+        = dsfr_modal(title: "Information importante", html_attributes: { id: "modal-3" }) do |component|
+          %p Bonjour ceci est important
+          - component.with_button(label: "Valider")
+          - component.with_button(label: "Annuler", level: :secondary, html_attributes: { "aria-controls": "modal-3" })
+        = dsfr_button(label: "Ouvrir la modale", html_attributes: { "data-fr-opened": false, "aria-controls": "modal-3" })
+      RAW
+    end
+  end
+end
+
+#   context "with title icon" do
+#     let(:args) { { title: "Information importante", title_icon: "fr-icon-arrow-right-line", html_attributes: { id: "modal-1" } } }
+#     let(:content) { "Bonjour ceci est important" }
+#
+#     it "renders correctly" do
+#       expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
+#         with_tag(:div, with: { class: "fr-modal__body" }) do
+#           with_tag(:h1, text: /Information importante/) do
+#             with_tag(:span, with: { class: "fr-icon-arrow-right-line fr-fi--lg" })
+#           end
+#         end
+#       end
+#     end
+#   end
+#
+#   context "with two buttons" do
+#     subject! do
+#       render_inline(described_class.new(title: "Information importante")) do |c|
+#         c.with_button(label: "Annuler", level: :secondary)
+#         c.with_button(label: "Valider")
+#         "Bonjour ceci est important"
+#       end
+#     end
+#
+#     it "renders correctly" do
+#       expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
+#         with_tag(:div, with: { class: "fr-modal__body" }, text: /Bonjour ceci est important/) do
+#           with_tag(:h1, text: /Information importante/)
+#         end
+#         with_tag(:div, with: { class: "fr-modal__footer" }) do
+#           with_tag(:button, with: { class: "fr-btn--secondary" }, text: /Annuler/)
+#           with_tag(:button, with: { class: "fr-btn" }, text: /Valider/)
+#         end
+#       end
+#     end
+#   end
+# end

--- a/guide/lib/examples/modal_helpers.rb
+++ b/guide/lib/examples/modal_helpers.rb
@@ -11,8 +11,9 @@ module Examples
     def modal_button
       <<~RAW
         = dsfr_modal(title: "Information importante", html_attributes: { id: "modal-2" }) do |component|
-          %p Bonjour ceci est important
-          - component.with_button(label: "Valider")
+          - component.with_button do
+            = dsfr_button label: "Valider"
+          %p Bonjour ceci est très important
         = dsfr_button(label: "Ouvrir la modale", html_attributes: { "data-fr-opened": false, "aria-controls": "modal-2" })
       RAW
     end
@@ -20,49 +21,24 @@ module Examples
     def modal_two_buttons
       <<~RAW
         = dsfr_modal(title: "Information importante", html_attributes: { id: "modal-3" }) do |component|
-          %p Bonjour ceci est important
-          - component.with_button(label: "Valider")
-          - component.with_button(label: "Annuler", level: :secondary, html_attributes: { "aria-controls": "modal-3" })
+          %p Bonjour ceci est extrêmement important
+          - component.with_button do
+            = dsfr_button label: "Valider"
+          - component.with_button do
+            = dsfr_button label: "Annuler", level: :secondary, html_attributes: { "aria-controls": "modal-3" }
         = dsfr_button(label: "Ouvrir la modale", html_attributes: { "data-fr-opened": false, "aria-controls": "modal-3" })
+      RAW
+    end
+
+    def modal_turbo
+      <<~RAW
+        = dsfr_modal(title: "Information importante", opened: true, html_attributes: { id: "modal-4" }) do |component|
+          %p Bonjour ceci est crucial
+          - component.with_button do
+            = dsfr_link_to "Valider", "#", class: "fr-btn"
+          - component.with_button do
+            = dsfr_link_to  "Annuler", "#", class: "fr-btn fr-btn--secondary"
       RAW
     end
   end
 end
-
-#   context "with title icon" do
-#     let(:args) { { title: "Information importante", title_icon: "fr-icon-arrow-right-line", html_attributes: { id: "modal-1" } } }
-#     let(:content) { "Bonjour ceci est important" }
-#
-#     it "renders correctly" do
-#       expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
-#         with_tag(:div, with: { class: "fr-modal__body" }) do
-#           with_tag(:h1, text: /Information importante/) do
-#             with_tag(:span, with: { class: "fr-icon-arrow-right-line fr-fi--lg" })
-#           end
-#         end
-#       end
-#     end
-#   end
-#
-#   context "with two buttons" do
-#     subject! do
-#       render_inline(described_class.new(title: "Information importante")) do |c|
-#         c.with_button(label: "Annuler", level: :secondary)
-#         c.with_button(label: "Valider")
-#         "Bonjour ceci est important"
-#       end
-#     end
-#
-#     it "renders correctly" do
-#       expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
-#         with_tag(:div, with: { class: "fr-modal__body" }, text: /Bonjour ceci est important/) do
-#           with_tag(:h1, text: /Information importante/)
-#         end
-#         with_tag(:div, with: { class: "fr-modal__footer" }) do
-#           with_tag(:button, with: { class: "fr-btn--secondary" }, text: /Annuler/)
-#           with_tag(:button, with: { class: "fr-btn" }, text: /Valider/)
-#         end
-#       end
-#     end
-#   end
-# end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -46,3 +46,4 @@ use_helper Examples::BadgeHelpers
 use_helper Examples::TagHelpers
 use_helper Examples::StepperHelpers
 use_helper Examples::ButtonHelpers
+use_helper Examples::ModalHelpers

--- a/spec/components/dsfr_component/modal_component_spec.rb
+++ b/spec/components/dsfr_component/modal_component_spec.rb
@@ -25,18 +25,20 @@ RSpec.describe(DsfrComponent::ModalComponent, type: :component) do
   context "with a primary button" do
     subject! do
       render_inline(described_class.new(title: "Information importante", html_attributes: { id: "modal-1" })) do |c|
-        c.with_button(label: "Valider")
-        "Bonjour ceci est important"
+        c.with_button { "<button class='fr-btn'>Valider</button>".html_safe }
+        "<p>Bonjour ceci est important</p>".html_safe
       end
     end
 
     it "renders correctly" do
       expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
-        with_tag(:div, with: { class: "fr-modal__body" }, text: /Bonjour ceci est important/) do
+        with_tag(:div, with: { class: "fr-modal__body" }) do
           with_tag(:h1, text: /Information importante/)
+          with_tag(:p, text: /Bonjour ceci est important/)
         end
         with_tag(:div, with: { class: "fr-modal__footer" }) do
-          with_tag(:button, with: { class: "fr-btn" }, text: /Valider/)
+          without_tag(:p) # checking that the content does not appear in the footer
+          with_tag(:button, class: "fr-btn", text: /Valider/)
         end
       end
     end
@@ -45,18 +47,20 @@ RSpec.describe(DsfrComponent::ModalComponent, type: :component) do
   context "with two buttons" do
     subject! do
       render_inline(described_class.new(title: "Information importante", html_attributes: { id: "modal-1" })) do |c|
-        c.with_button(label: "Valider")
-        c.with_button(label: "Annuler", level: :secondary)
-        "Bonjour ceci est important"
+        c.with_button { "<button class='fr-btn'>Valider</button>".html_safe }
+        c.with_button { "<button class='fr-btn fr-btn--secondary'>Annuler</button>".html_safe }
+        "<p>Bonjour ceci est important</p>".html_safe
       end
     end
 
     it "renders correctly" do
       expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
-        with_tag(:div, with: { class: "fr-modal__body" }, text: /Bonjour ceci est important/) do
+        with_tag(:div, with: { class: "fr-modal__body" }) do
           with_tag(:h1, text: /Information importante/)
+          with_tag(:p, text: /Bonjour ceci est important/)
         end
         with_tag(:div, with: { class: "fr-modal__footer" }) do
+          without_tag(:p)
           with_tag(:button, with: { class: "fr-btn--secondary" }, text: /Annuler/)
           with_tag(:button, with: { class: "fr-btn" }, text: /Valider/)
         end

--- a/spec/components/dsfr_component/modal_component_spec.rb
+++ b/spec/components/dsfr_component/modal_component_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe(DsfrComponent::ModalComponent, type: :component) do
+  subject! { render_inline(described_class.new(**args).with_content(content)) }
+
+  context "with simple args" do
+    let(:args) { { title: "Information importante", html_attributes: { id: "modal-1" } } }
+    let(:content) { "Bonjour ceci est important" }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
+        with_tag(:div, with: { class: "fr-modal__header" }) do
+          with_tag(:button, with: { class: "fr-link--close fr-link", "aria-controls": "modal-1" }, text: "Fermer")
+        end
+        with_tag(:div, with: { class: "fr-modal__body" }) do
+          with_tag(:h1, text: /Information importante/) do
+            without_tag(:span)
+          end
+        end
+        without_tag(:div, with: { class: "fr-modal__footer" })
+      end
+    end
+  end
+
+  context "with a primary button" do
+    subject! do
+      render_inline(described_class.new(title: "Information importante", html_attributes: { id: "modal-1" })) do |c|
+        c.with_button(label: "Valider")
+        "Bonjour ceci est important"
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
+        with_tag(:div, with: { class: "fr-modal__body" }, text: /Bonjour ceci est important/) do
+          with_tag(:h1, text: /Information importante/)
+        end
+        with_tag(:div, with: { class: "fr-modal__footer" }) do
+          with_tag(:button, with: { class: "fr-btn" }, text: /Valider/)
+        end
+      end
+    end
+  end
+
+  context "with two buttons" do
+    subject! do
+      render_inline(described_class.new(title: "Information importante", html_attributes: { id: "modal-1" })) do |c|
+        c.with_button(label: "Valider")
+        c.with_button(label: "Annuler", level: :secondary)
+        "Bonjour ceci est important"
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
+        with_tag(:div, with: { class: "fr-modal__body" }, text: /Bonjour ceci est important/) do
+          with_tag(:h1, text: /Information importante/)
+        end
+        with_tag(:div, with: { class: "fr-modal__footer" }) do
+          with_tag(:button, with: { class: "fr-btn--secondary" }, text: /Annuler/)
+          with_tag(:button, with: { class: "fr-btn" }, text: /Valider/)
+        end
+      end
+    end
+  end
+
+  context "without an id" do
+    subject! do
+      render_inline(described_class.new(title: "Information importante").with_content("Bonjour ceci est important"))
+    end
+
+    it "renders correctly without breaking" do
+      expect(rendered_content).to have_tag(:dialog, with: { class: "fr-modal" }) do
+        with_tag(:div, with: { class: "fr-modal__body" }, text: /Bonjour ceci est important/) do
+          with_tag(:h1, text: /Information importante/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
cf #85 

Note: this is based on #150 as the ModalComponent depends on the ButtonComponent one

- I have not handled the case where you want to use an icon in the title, we can do it later I think
- a modal without an explicit html `id` is pretty much useless since you cannot refer to it in any button to open it. In this PR I’ve left it to the user to pass it with the regular `html_attributes: { id: "modal-1" }` kwarg. I don’t require the presence of this attribute, the component won’t fail if you don’t pass it. It will just be harder to use it (you’d need custom JS). We could instead have an explicitly required `id` param in the component, but it’d be redundant with the `html_attributes` one. I don’t have a strong opinion on this.
- for the buttons slots I’ve made it rather simple : it’s always a buttons group even when there is only a single button. It seems to look identical so it’s easier to code this way 🤷 I was a bit lazy on that one.
- We could in the future have a `cancel_button` slot shortcut that would pre-fill the `data-fr-opened` and `aria-controls` attributes. 
- I don’t really know what kind of API we could think of for the external opening button. maybe an option to the `ButtonComponent` or a variant or a subcomponent that takes a modal component as an argument and auto fills the `data-fr-opened` and `aria-controls` attributes ? That’s a thought for later though.
- in the guide previews I had to hack the panel contents to be higher because the modal pops in INSIDE these panel contents for some reason


![image](https://user-images.githubusercontent.com/883348/220711570-388abae4-a2c2-4853-9abe-2f2d1875e0b6.png)

<img width="1066" alt="Screenshot 2023-02-22 at 18 43 46" src="https://user-images.githubusercontent.com/883348/220711629-6cd1863c-36e1-4aaa-bc1a-f957cfa5a374.png">
