### PR TITLE
component: Button

### DIFF
--- a/app/components/dsfr_component/button_component.rb
+++ b/app/components/dsfr_component/button_component.rb
@@ -1,0 +1,63 @@
+module DsfrComponent
+  class ButtonComponent < DsfrComponent::Base
+    SIZES = %i[sm md lg].freeze
+    ICON_POSITIONS = %i[left right].freeze
+    ICON_LEVELS = %i[primary secondary tertiary].freeze
+
+    # @param label [String] Le label du bouton (optionnel si un icône présent)
+    # @param icon [String] Le nom de l’icône à afficher (exemple `arrow-right-line`) (optionnel)
+    # @param icon_position [String] Position de l’icône : :left (défaut) ou :right (optionnel)
+    # @param title [String] Le titre du bouton permettant d’afficher une infobulle (optionnel)
+    # @param level [String] Le niveau du bouton : :primary (défaut), :secondary ou :tertiary (optionnel)
+    # @param size [String] La taille du bouton : :sm, :md (défaut), :lg (optionnel)
+    def initialize(label: nil, title: nil, icon: nil, icon_position: :left, level: nil, size: nil, classes: [], html_attributes: {})
+      @label = label
+      @title = title
+      @icon = icon
+      @icon_position = icon_position
+      @level = level
+      @outline = outline
+      @size = size
+
+      validate_size
+      validate_icon_position
+      validate_level
+      validate_label
+
+      super(classes: classes, html_attributes: html_attributes)
+    end
+
+    def call
+      tag.button(**html_attributes) { label }
+    end
+
+  private
+
+    attr_reader :label, :icon, :icon_position, :level, :outline, :size
+
+    def default_attributes
+      classes = ["fr-btn"]
+      classes << "fr-btn--#{level}" if level.present?
+      classes << "fr-btn--#{size}" if size.present?
+      classes << "fr-icon-#{icon}" if icon.present?
+      classes << "fr-btn--icon-#{icon_position}" if icon.present? && label.present?
+      { class: classes }
+    end
+
+    def validate_size
+      raise(ArgumentError, "`size` should be one of #{SIZES}") if size.present? && SIZES.exclude?(size)
+    end
+
+    def validate_icon_position
+      raise(ArgumentError, "`icon_position` should be one of #{ICON_POSITIONS}") if icon_position.present? && ICON_POSITIONS.exclude?(icon_position)
+    end
+
+    def validate_level
+      raise(ArgumentError, "`level` should be one of #{ICON_LEVELS}") if level.present? && ICON_LEVELS.exclude?(level)
+    end
+
+    def validate_label
+      raise(ArgumentError, "`label` is required unless an icon is specified") if label.blank? && icon.blank?
+    end
+  end
+end

--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -8,6 +8,7 @@ module DsfrComponentsHelper
     dsfr_badge: 'DsfrComponent::BadgeComponent',
     dsfr_tag: 'DsfrComponent::TagComponent',
     dsfr_stepper: 'DsfrComponent::StepperComponent',
+    dsfr_button: 'DsfrComponent::ButtonComponent',
     # DO NOT REMOVE: new component mapping here
   }.freeze
   HELPER_NAME_TO_CLASS_NAME.each do |name, klass|

--- a/guide/content/components/button.haml
+++ b/guide/content/components/button.haml
@@ -1,0 +1,38 @@
+---
+title: Button
+---
+
+.fr-text-wrap
+  :markdown
+    Le bouton est un élément d’interaction avec l’interface permettant à l’utilisateur d’effectuer une action.
+
+= render('/partials/example.haml', caption: "Boutons de niveaux différents", code: button_levels) do
+  :markdown
+    Le rendu par défaut d’un bouton.
+    Le bouton secondaire est utilisé lorsque l’action est moins prioritaire que l'action principale, comme réinitialiser les valeurs d’un formulaire.
+    Le bouton tertiaire est réservé pour des actions contextuelles ou alternatives : fermeture de modale, annuler, réinitialiser, partager, suivre sur un réseau social, copier un lien.
+
+= render('/partials/example.haml', caption: "Bouton désactivé", code: button_disabled) do
+  :markdown
+    L'état désactivé indique que l'utilisateur ne peut pas interagir avec le bouton. Il ne doit être utilisé que très ponctuellement. Par exemple, lorsqu’on veut indiquer à l’utilisateur qu’il doit procéder à une action en amont.
+
+= render('/partials/example.haml', caption: "Bouton avec icône", code: button_icons) do
+  :markdown
+    Il est possible d'ajouter une icône à votre bouton permettant une meilleure compréhension de l’action. Pour cela il suffit d’utiliser la classe CSS de l’icône (voir la documentation des icônes)
+    La position de l’icône peut être changée en ajoutant la classe `fr-btn--icon-right` à votre bouton.
+
+= render('/partials/example.haml', caption: "Bouton uniquement avec icône", code: button_icon_only) do
+  :markdown
+    Limitez l’usage des boutons à icône seule.
+    Ils peuvent être utilisés uniquement pour les actions récurrentes, et facilement identifiable (ex : engrenage pour les paramètres ou loupe pour la recherche).
+    Ce button doit contenir un libellé, qui sera ainsi lu par les assistants.
+    L'attribut title reprenant l'intitulé du bouton peut être ajouté pour permettre l'affichage d'une infobulle.
+
+= render('/partials/example.haml', caption: "Boutons de tailles différentes", code: button_sizes) do
+  :markdown
+    La taille medium (`:md`) est la taille de bouton par défaut.
+    Les tailles `:md` et `:lg` sont à utiliser en priorité.
+    La taille `:sm` pourra être utilisé pour créer certains composants, évitez de l’utiliser en mobile car la zone de “touch” sur écran tactile n’est pas suffisante.
+
+
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("Bouton"))

--- a/guide/lib/examples/button_helpers.rb
+++ b/guide/lib/examples/button_helpers.rb
@@ -1,0 +1,33 @@
+module Examples
+  module ButtonHelpers
+    def button_levels
+      <<~RAW
+        = dsfr_button(label: "Valider")
+        = dsfr_button(label: "Valider", level: :secondary)
+        = dsfr_button(label: "Valider", level: :tertiary)
+      RAW
+    end
+
+    def button_disabled
+      '= dsfr_button(label: "Valider", html_attributes: { disabled: true })'
+    end
+
+    def button_icons
+      <<~RAW
+        = dsfr_button(label: "Valider", icon: "checkbox-circle-line")
+        = dsfr_button(label: "Valider", icon: "checkbox-circle-line", icon_position: :right)
+      RAW
+    end
+
+    def button_icon_only
+      '= dsfr_button(icon: "checkbox-circle-line", html_attributes: { title: "Valider" })'
+    end
+
+    def button_sizes
+      <<~RAW
+        = dsfr_button(label: "Valider", size: :sm)
+        = dsfr_button(label: "Valider", size: :lg)
+      RAW
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -45,3 +45,4 @@ use_helper Examples::TileHelpers
 use_helper Examples::BadgeHelpers
 use_helper Examples::TagHelpers
 use_helper Examples::StepperHelpers
+use_helper Examples::ButtonHelpers

--- a/spec/components/dsfr_component/button_component_spec.rb
+++ b/spec/components/dsfr_component/button_component_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe(DsfrComponent::ButtonComponent, type: :component) do
+  subject! { render_inline(described_class.new(**args)) }
+
+  context "when simple button" do
+    let(:args) { { label: "Valider" } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn" }, text: "Valider")
+    end
+  end
+
+  context "when secondary button" do
+    let(:args) { { label: "Valider", level: :secondary } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-btn--secondary" }, text: "Valider")
+    end
+  end
+
+  context "when tertiary button" do
+    let(:args) { { label: "Valider", level: :tertiary } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-btn--tertiary" }, text: "Valider")
+    end
+  end
+
+  context "when disabled button" do
+    let(:args) { { label: "Valider", html_attributes: { disabled: true } } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn", disabled: "disabled" }, text: "Valider")
+    end
+  end
+
+  context "when icon default position left" do
+    let(:args) { { label: "Valider", icon: "checkbox-circle-line" } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-btn--icon-left fr-icon-checkbox-circle-line" }, text: "Valider")
+    end
+  end
+
+  context "when icon explicit position left" do
+    let(:args) { { label: "Valider", icon: "checkbox-circle-line", icon_position: :left } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-btn--icon-left fr-icon-checkbox-circle-line" }, text: "Valider")
+    end
+  end
+
+  context "when icon right" do
+    let(:args) { { label: "Valider", icon: "checkbox-circle-line", icon_position: :right } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-btn--icon-right fr-icon-checkbox-circle-line" }, text: "Valider")
+    end
+  end
+
+  context "when icon-only button" do
+    let(:args) { { icon: "checkbox-circle-line", html_attributes: { title: "Valider" } } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-icon-checkbox-circle-line", title: "Valider" }, text: nil)
+    end
+  end
+
+  context "when small button" do
+    let(:args) { { label: "Valider", size: :sm } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-btn--sm" }, text: "Valider")
+    end
+  end
+
+  context "when large button" do
+    let(:args) { { label: "Valider", size: :lg } }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:button, with: { class: "fr-btn fr-btn--lg" }, text: "Valider")
+    end
+  end
+end


### PR DESCRIPTION
cf #62

- I used the `label` param name for the actual button content as does the DSFR guide because it’s also possible to set a tag attribute `title` on the `<button>` tag. 
- I used a single `:level` param that takes `:primary, :secondary or :tertiary`. we could also use `primary: true`, `secondary: true`... I don’t really have a preference
- I used an `icon` param that takes the class name without the `fr-icon-` prefix, i.e. `checkbox-line` + a second param `icon_position : :left or :right`. This is quite different from what you had done with the `dsfr_link_to` helper but I believe it’s a better direction. I feel it should be easy to add an icon without thinking about its position, so `icon: "checkbox-line"` should work on its own. I don’t have a strong opinion though.

icons are broken in the guide but i think it’s okay, I’ll double check 

![image](https://user-images.githubusercontent.com/883348/220681505-fdba5cce-0376-4441-8317-b8636400f9b3.png)