### PR TITLE
component: header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,12 @@ Style/HashSyntax:
 Metrics/ParameterLists:
   Enabled: False
 
+RSpec/ExampleLength:
+  Enabled: False
+
+RSpec/RepeatedExampleGroupBody:
+  Enabled: False
+
 Naming/FileName:
   Exclude:
     - guide/Rules

--- a/app/components/dsfr_component/header_component.html.erb
+++ b/app/components/dsfr_component/header_component.html.erb
@@ -1,0 +1,94 @@
+<%= tag.header(**html_attributes) do %>
+  <div class="fr-header__body">
+    <div class="fr-container">
+      <div class="fr-header__body-row">
+        <div class="fr-header__brand fr-enlarge-link">
+          <div class="fr-header__brand-top">
+            <div class="fr-header__logo">
+              <p class="fr-logo"><%= logo_text %></p>
+            </div>
+
+            <% if search? || tool_links? || direct_links? %>
+              <div class="fr-header__navbar">
+                <% if search? %>
+                  <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-header-search" id="button-header-search" title="Rechercher">
+                    Rechercher
+                  </button>
+                <% end %>
+
+                <% if tool_links? || direct_links? %>
+                  <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-header-menu" aria-haspopup="menu" id="button-header-menu" title="Menu">
+                    Menu
+                  </button>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+
+          <div class="fr-header__service">
+            <a href="/" title="Accueil - <%= title %>">
+              <p class="fr-header__service-title"><%= title %></p>
+            </a>
+            <% if tagline %>
+              <p class="fr-header__service-tagline"><%= tagline %></p>
+            <% end %>
+          </div>
+        </div>
+
+        <% if tool_links? || search? %>
+          <div class="fr-header__tools">
+            <% if tool_links? %>
+              <div class="fr-header__tools-links">
+                <ul class="fr-btns-group">
+                  <% tool_links.each do |tool_link| %>
+                    <li>
+                      <%= tool_link %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+
+            <% if search? %>
+              <div class="fr-header__search fr-modal" id="modal-header-search">
+                <div class="fr-container fr-container-lg--fluid">
+                  <button class="fr-btn--close fr-btn" aria-controls="modal-header-search" title="Fermer">
+                    Fermer
+                  </button>
+                  <div role="search" id="header-search">
+                    <%= search %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <% if tool_links? || direct_links? %>
+    <div class="fr-header__menu fr-modal" id="modal-header-menu" aria-labelledby="button-header-menu">
+      <div class="fr-container">
+        <button class="fr-btn--close fr-btn" aria-controls="modal-header-menu" title="Fermer">
+          Fermer
+        </button>
+        <div class="fr-header__menu-links">
+          <!-- this seems to get autopopulated with the tool links with JS -->
+        </div>
+
+        <% if direct_links? %>
+          <nav class="fr-nav" id="navigation-direct-links" role="navigation" aria-label="Menu principal">
+            <ul class="fr-nav__list">
+              <% direct_links.each do |direct_link| %>
+                <li class="fr-nav__item">
+                  <%= direct_link %>
+                </li>
+              <% end %>
+            </ul>
+          </nav>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/dsfr_component/header_component.rb
+++ b/app/components/dsfr_component/header_component.rb
@@ -1,0 +1,27 @@
+class DsfrComponent::HeaderComponent < DsfrComponent::Base
+  renders_one :search
+  renders_many :tool_links, "DsfrComponent::HeaderComponent::ToolLinkComponent"
+  renders_many :direct_links, types: {
+    simple: "DsfrComponent::HeaderComponent::DirectLinkComponent",
+    dropdown: "DsfrComponent::HeaderComponent::DirectLinkDropdownComponent"
+  }
+
+  # @param logo_text [String] Ce texte obligatoire sera affiché en dessous de la Marianne et au dessus de la devise française. C’est généralement un nom de ministère ou d’administration.
+  # @param title [String] Le nom du service numérique, titre principal du site.
+  # @param tagline [String] La description du service numérique, sous-titre du site (optionnelle).
+  def initialize(logo_text:, title:, tagline: nil, classes: [], html_attributes: {})
+    @logo_text = logo_text
+    @title = title
+    @tagline = tagline
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+private
+
+  attr_reader :logo_text, :title, :tagline
+
+  def default_attributes
+    { class: 'fr-header', role: 'banner' }
+  end
+end

--- a/app/components/dsfr_component/header_component/direct_link_component.rb
+++ b/app/components/dsfr_component/header_component/direct_link_component.rb
@@ -1,0 +1,22 @@
+class DsfrComponent::HeaderComponent::DirectLinkComponent < DsfrComponent::Base
+  def initialize(title:, path:, active: false, classes: [], html_attributes: {})
+    @title = title
+    @path = path
+    @active = active
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  def call
+    tag.a(title, **html_attributes)
+  end
+
+private
+
+  attr_reader :title, :path, :active
+
+  def default_attributes
+    { href: path, class: 'fr-nav__link', target: "_self" } \
+      .merge(active ? { "aria-current": 'page' } : {})
+  end
+end

--- a/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
+++ b/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
@@ -5,7 +5,7 @@ class DsfrComponent::HeaderComponent::DirectLinkDropdownComponent < DsfrComponen
     @title = title
     @active = active
 
-    super classes: classes, html_attributes: html_attributes
+    super(classes: classes, html_attributes: html_attributes)
   end
 
   def call

--- a/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
+++ b/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
@@ -1,0 +1,34 @@
+class DsfrComponent::HeaderComponent::DirectLinkDropdownComponent < DsfrComponent::Base
+  renders_many :links, DsfrComponent::HeaderComponent::DirectLinkComponent
+
+  def initialize(title:, active: false, classes: [], html_attributes: {})
+    @title = title
+    @active = active
+
+    super classes: classes, html_attributes: html_attributes
+  end
+
+  def call
+    tag.button(title, **html_attributes) +
+      tag.div(class: 'fr-collapse fr-menu', id: menu_id) do
+        tag.ul(class: 'fr-menu__list') do
+          links.map do |link|
+            tag.li link.call
+          end.join.html_safe
+        end
+      end
+  end
+
+private
+
+  attr_reader :title, :active
+
+  def default_attributes
+    { class: 'fr-nav__btn', "aria-expanded": "false", "aria-controls": menu_id } \
+      .merge(active ? { "aria-current": 'true' } : {})
+  end
+
+  def menu_id
+    @menu_id ||= "menu-#{title.parameterize}"
+  end
+end

--- a/app/components/dsfr_component/header_component/tool_link_component.rb
+++ b/app/components/dsfr_component/header_component/tool_link_component.rb
@@ -1,0 +1,20 @@
+class DsfrComponent::HeaderComponent::ToolLinkComponent < DsfrComponent::Base
+  def initialize(title:, path:, classes: [], html_attributes: {})
+    @title = title
+    @path = path
+
+    super classes: classes, html_attributes: html_attributes
+  end
+
+  def call
+    tag.a title, href: path, **html_attributes
+  end
+
+private
+
+  attr_reader :title, :path
+
+  def default_attributes
+    { class: 'fr-btn' }
+  end
+end

--- a/app/components/dsfr_component/header_component/tool_link_component.rb
+++ b/app/components/dsfr_component/header_component/tool_link_component.rb
@@ -3,7 +3,7 @@ class DsfrComponent::HeaderComponent::ToolLinkComponent < DsfrComponent::Base
     @title = title
     @path = path
 
-    super classes: classes, html_attributes: html_attributes
+    super(classes: classes, html_attributes: html_attributes)
   end
 
   def call

--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -10,6 +10,10 @@ module DsfrComponentsHelper
     dsfr_stepper: 'DsfrComponent::StepperComponent',
     dsfr_button: 'DsfrComponent::ButtonComponent',
     dsfr_modal: 'DsfrComponent::ModalComponent',
+    dsfr_header: 'DsfrComponent::HeaderComponent',
+    dsfr_header_tool_link: 'DsfrComponent::HeaderComponent::ToolLinkComponent',
+    dsfr_header_direct_link: 'DsfrComponent::HeaderComponent::DirectLinkComponent',
+    dsfr_header_direct_dropdown_link: 'DsfrComponent::HeaderComponent::DirectLinkDropdownComponent',
     # DO NOT REMOVE: new component mapping here
   }.freeze
   HELPER_NAME_TO_CLASS_NAME.each do |name, klass|

--- a/guide/content/components/header.haml
+++ b/guide/content/components/header.haml
@@ -1,0 +1,49 @@
+---
+title: En-tête - Header
+---
+
+.fr-text-wrap
+  :markdown
+    L’en-tête permet aux utilisateurs d’identifier sur quel site ils se trouvent. Il peut donner accès à la recherche et à certaines pages ou fonctionnalités clés.
+
+= render '/partials/example.haml', caption: "En-tête minimale", code: header_simple do
+  :markdown
+    Un header minimal est composé d’un logo textuel et d’un titre.
+
+= render '/partials/example.haml', caption: "En-tête avec un logo sur deux lignes", code: header_logo_lines do
+  :markdown
+    Le texte du logo peut être sur deux lignes en ajoutant une classe CSS personnalisée
+
+= render '/partials/example.haml', caption: "En-tête avec des accès rapides", code: header_with_tool_links do
+  :markdown
+    Un header peut présenter des liens d’accès rapide (*tool links* dans le code).
+
+= render '/partials/example.haml', caption: "En-tête avec des liens directs", code: header_with_simple_direct_links do
+  :markdown
+    Un header peut présenter des liens directs (*direct links* dans le code).
+
+= render '/partials/example.haml', caption: "En-tête avec des liens déroulants", code: header_with_dropdown_direct_links, output_class: "fr-pb-16w" do
+  :markdown
+    Un header peut présenter des liens directs déroulants (*dropdown* dans le code).
+
+%h3.fr-mt-8w#mega-menu
+  %a.header-anchor{href: "#mega-menu"}
+    En-tête avec un méga menu
+.fr-mb-8w
+  :markdown
+    Le [méga menu](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/navigation-principale/){:target="_blank" rel="noopener"} n’est pas encore développé dans cette gem.
+
+= render '/partials/example.haml', caption: "En-tête avec un champ de recherche", code: header_with_search do
+  :markdown
+    Un header peut présenter un champ de recherche.
+    Le formulaire de recherche est à implémenter vous-même.
+    La classe `.fr-search-bar` peut être utilisée pour faciliter l’implémentation d’un formulaire en ligne avec le bouton submit sur la droite.
+
+    Dans cet exemple nous codons le formulaire en HAML brut, mais vous pouvez utiliser les helpers de Rails comme `form_for`.
+
+= render '/partials/example.haml', caption: "En-tête avec toutes les fonctionnalités", code: header_full, output_class: "fr-pb-16w" do
+  :markdown
+    Cet exemple regroupe toutes les fonctionnalités d’un header.
+
+.fr-mt-4w
+  = render '/partials/related-info.haml', links: dsfr_component_doc_link("Header", "en-tete")

--- a/guide/layouts/partials/example.haml
+++ b/guide/layouts/partials/example.haml
@@ -41,7 +41,8 @@
     .fr-tabs__panel.fr-tabs__panel--selected{
       role: "tabpanel",
       "aria-labelledby" => "output-rendered-#{anchor_id(caption)}",
-      id: "output-rendered-#{anchor_id(caption)}"
+      id: "output-rendered-#{anchor_id(caption)}",
+      class: defined?(output_class) ? output_class : ""
     }
       = format_haml(code)
 

--- a/guide/lib/examples/header_helpers.rb
+++ b/guide/lib/examples/header_helpers.rb
@@ -1,0 +1,77 @@
+module Examples
+  module HeaderHelpers
+    def header_simple
+      '= dsfr_header logo_text: "Ministère du Travail", title: "Égapro"'
+    end
+
+    def header_logo_lines
+      <<~HEADER
+        = dsfr_header logo_text: "Ministère \\ndu Travail", title: "Égapro", classes: ["logo-pre-line"]
+
+        :css
+          .logo-pre-line .fr-logo {
+            white-space: pre-line;
+          }
+      HEADER
+    end
+
+    def header_with_tool_links
+      <<~HEADER
+        = dsfr_header logo_text: "Ministère du Travail", title: "Égapro", tagline: "Indice de parité professionelle" do |header|
+          - header.with_tool_link title: "Comment ça marche", path: "#comment-ca-marche"
+          - header.with_tool_link title: "Contact", path: "#contact", classes: ["fr-icon-mail-line"]
+      HEADER
+    end
+
+    def header_with_simple_direct_links
+      <<~HEADER
+        = dsfr_header logo_text: "Ministère du Travail", title: "Égapro", tagline: "Indice de parité professionelle" do |header|
+          - header.with_direct_link_simple title: "Comment ça marche", path: "#comment-ca-marche"
+          - header.with_direct_link_simple title: "Contact", path: "#contact"
+      HEADER
+    end
+
+    def header_with_dropdown_direct_links
+      <<~HEADER
+        = dsfr_header logo_text: "Ministère du Travail", title: "Égapro", tagline: "Indice de parité professionelle" do |header|
+          = header.with_direct_link_dropdown title: "Aide" do |dropdown|
+            = dropdown.with_link title: "Comment ça marche", path: "#comment-ca-marche"
+            = dropdown.with_link title: "Contact", path: "#contact"
+          = header.with_direct_link_dropdown title: "Environnement" do |dropdown|
+            = dropdown.with_link title: "Beta Gouv", path: "#beta-gouv"
+            = dropdown.with_link title: "DSFR", path: "#dsfr"
+      HEADER
+    end
+
+    def header_with_search
+      <<~HEADER
+        = dsfr_header logo_text: "Ministère du Travail", title: "Égapro", tagline: "Indice de parité professionelle" do |header|
+          - header.with_search do
+            %form
+              .fr-search-bar(role="search")
+                %label.fr-label(for="nom") Rechercher une entreprise
+                %input.fr-input(type="text" name="nom" id="nom" placeholder="Nom de l’entreprise")
+                %button.fr-btn(type="submit")
+      HEADER
+    end
+
+    def header_full
+      <<~HEADER
+        = dsfr_header logo_text: "Ministère du Travail", title: "Égapro", tagline: "Indice de parité professionelle" do |header|
+          - header.with_tool_link title: "Connexion", path: "#connexion"
+          - header.with_tool_link title: "FAQ", path: "#FAQ", classes: ["fr-icon-question-line"]
+          - header.with_direct_link_simple title: "Comment ça marche", path: "#comment-ca-marche"
+          = header.with_direct_link_dropdown title: "Environnement" do |dropdown|
+            = dropdown.with_link title: "Beta Gouv", path: "#beta-gouv"
+            = dropdown.with_link title: "DSFR", path: "#dsfr"
+          - header.with_direct_link_simple title: "Contact", path: "#contact"
+          - header.with_search do
+            %form
+              .fr-search-bar(role="search")
+                %label.fr-label(for="nom") Rechercher une entreprise
+                %input.fr-input(type="text" name="nom" id="nom" placeholder="Nom de l’entreprise")
+                %button.fr-btn(type="submit")
+      HEADER
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -47,3 +47,4 @@ use_helper Examples::TagHelpers
 use_helper Examples::StepperHelpers
 use_helper Examples::ButtonHelpers
 use_helper Examples::ModalHelpers
+use_helper Examples::HeaderHelpers

--- a/spec/components/dsfr_component/header_component_spec.rb
+++ b/spec/components/dsfr_component/header_component_spec.rb
@@ -1,0 +1,209 @@
+require "spec_helper"
+
+RSpec.describe(DsfrComponent::HeaderComponent, type: :component) do
+  context "with only a logo and a title" do
+    subject! { render_inline described_class.new(logo_text: "Ministère du Travail", title: "Égapro") }
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag("header", with: { class: "fr-header" }) do
+        with_tag "div", with: { class: "fr-header__body" } do
+          with_tag "div", with: { class: "fr-header__logo" } do
+            with_tag "p", with: { class: "fr-logo" }, text: "Ministère du Travail"
+          end
+          without_tag "div", with: { class: "fr-header__navbar" }
+          with_tag "div", with: { class: "fr-header__service" } do
+            with_tag "p", with: { class: "fr-header__service-title" }, text: "Égapro"
+            without_tag "p", with: { class: "fr-header__service-tagline" }, text: "Indice de parité professionelle"
+          end
+          without_tag "div", with: { class: "fr-header__tools" }
+        end
+        without_tag "div", with: { class: "fr-header__menu" }
+      end
+    end
+  end
+
+  context "with tool links" do
+    subject! do
+      render_inline(
+        described_class.new(
+          logo_text: "Ministère du Travail",
+          title: "Égapro",
+          tagline: "Indice de parité professionelle"
+        )
+      ) do |component|
+        component.with_tool_link title: "Comment ça marche", path: "#comment-ca-marche"
+        component.with_tool_link title: "Contact", path: "#contact", classes: ["fr-icon-mail-line"]
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag("header", with: { class: "fr-header" }) do
+        with_tag "div", with: { class: "fr-header__body" } do
+          with_tag "div", with: { class: "fr-header__logo" } do
+            with_tag "p", with: { class: "fr-logo" }, text: "Ministère du Travail"
+          end
+          with_tag "div", with: { class: "fr-header__navbar" } do
+            without_tag "button", text: /Rechercher/
+            with_tag "button", text: /Menu/
+          end
+          with_tag "div", with: { class: "fr-header__service" } do
+            with_tag "p", with: { class: "fr-header__service-title" }, text: "Égapro"
+            with_tag "p", with: { class: "fr-header__service-tagline" }, text: "Indice de parité professionelle"
+          end
+          with_tag "div", with: { class: "fr-header__tools" } do
+            with_tag "div", with: { class: "fr-header__tools-links" } do
+              with_tag "a", with: { class: "fr-btn", href: "#comment-ca-marche" }, text: "Comment ça marche"
+              with_tag "a", with: { class: "fr-btn fr-icon-mail-line", href: "#contact" }, text: "Contact"
+            end
+            without_tag "div", with: { class: "fr-header__search" }
+          end
+        end
+      end
+    end
+  end
+
+  context "with simple direct links" do
+    subject! do
+      render_inline(
+        described_class.new(
+          logo_text: "Ministère du Travail",
+          title: "Égapro",
+          tagline: "Indice de parité professionelle"
+        )
+      ) do |component|
+        component.with_direct_link_simple title: "Comment ça marche", path: "#comment-ca-marche"
+        component.with_direct_link_simple title: "Contact", path: "#contact"
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag("header", with: { class: "fr-header" }) do
+        with_tag "div", with: { class: "fr-header__body" } do
+          with_tag "div", with: { class: "fr-header__logo" } do
+            with_tag "p", with: { class: "fr-logo" }, text: "Ministère du Travail"
+          end
+          with_tag "div", with: { class: "fr-header__navbar" } do
+            without_tag "button", text: /Rechercher/
+            with_tag "button", text: /Menu/
+          end
+          with_tag "div", with: { class: "fr-header__service" } do
+            with_tag "p", with: { class: "fr-header__service-title" }, text: "Égapro"
+            with_tag "p", with: { class: "fr-header__service-tagline" }, text: "Indice de parité professionelle"
+          end
+          without_tag "div", with: { class: "fr-header__tools" }
+        end
+        with_tag "div", with: { class: "fr-header__menu" } do
+          with_tag "nav", with: { class: "fr-nav" } do
+            with_tag "a", with: { class: "fr-nav__link", href: "#comment-ca-marche" }, text: "Comment ça marche"
+            with_tag "a", with: { class: "fr-nav__link", href: "#contact" }, text: "Contact"
+          end
+          without_tag "div", with: { class: "fr-header__search" }
+        end
+      end
+    end
+  end
+
+  context "with dropdown direct links" do
+    subject! do
+      render_inline(
+        described_class.new(
+          logo_text: "Ministère du Travail",
+          title: "Égapro",
+          tagline: "Indice de parité professionelle"
+        )
+      ) do |component|
+        component.with_direct_link_dropdown title: "Aide" do |dropdown|
+          dropdown.with_link title: "Comment ça marche", path: "#comment-ca-marche"
+          dropdown.with_link title: "Contact", path: "#contact"
+        end
+        component.with_direct_link_dropdown title: "Environnement" do |dropdown|
+          dropdown.with_link title: "Beta Gouv", path: "#beta-gouv"
+          dropdown.with_link title: "DSFR", path: "#dsfr"
+        end
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag("header", with: { class: "fr-header" }) do
+        with_tag "div", with: { class: "fr-header__body" } do
+          with_tag "div", with: { class: "fr-header__logo" } do
+            with_tag "p", with: { class: "fr-logo" }, text: "Ministère du Travail"
+          end
+          with_tag "div", with: { class: "fr-header__navbar" } do
+            without_tag "button", text: /Rechercher/
+            with_tag "button", text: /Menu/
+          end
+          with_tag "div", with: { class: "fr-header__service" } do
+            with_tag "p", with: { class: "fr-header__service-title" }, text: "Égapro"
+            with_tag "p", with: { class: "fr-header__service-tagline" }, text: "Indice de parité professionelle"
+          end
+          without_tag "div", with: { class: "fr-header__tools" }
+        end
+        with_tag "div", with: { class: "fr-header__menu" } do
+          with_tag "nav", with: { class: "fr-nav" } do
+            with_tag "button", with: { class: "fr-nav__btn", "aria-controls": "menu-aide" }, text: "Aide"
+            with_tag :div, with: { class: "fr-menu", id: "menu-aide" } do
+              with_tag :a, with: { class: "fr-nav__link", href: "#comment-ca-marche" }, text: "Comment ça marche"
+              with_tag :a, with: { class: "fr-nav__link", href: "#contact" }, text: "Contact"
+            end
+            with_tag "button", with: { class: "fr-nav__btn", "aria-controls": "menu-environnement" }, text: "Environnement"
+            with_tag :div, with: { class: "fr-menu", id: "menu-environnement" } do
+              with_tag :a, with: { class: "fr-nav__link", href: "#beta-gouv" }, text: "Beta Gouv"
+              with_tag :a, with: { class: "fr-nav__link", href: "#dsfr" }, text: "DSFR"
+            end
+          end
+          without_tag "div", with: { class: "fr-header__search" }
+        end
+      end
+    end
+  end
+
+  # rubocop:disable Rails/OutputSafety
+  context "with search form" do
+    subject! do
+      render_inline(
+        described_class.new(
+          logo_text: "Ministère du Travail",
+          title: "Égapro",
+          tagline: "Indice de parité professionelle"
+        )
+      ) do |component|
+        component.with_search do
+          <<~HTML.html_safe
+            <form>
+              <div class="fr-search-bar" role="search">
+                <label class="fr-label" for="nom">Rechercher une entreprise</label>
+                <input placeholder="Rechercher une entreprise" autocomplete="off" class="fr-input" type="text" name="nom" id="nom">
+                <button name="button" type="submit" class="fr-btn">Rechercher</button>
+              </div>
+            </form>
+          HTML
+        end
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag("header", with: { class: "fr-header" }) do
+        with_tag "div", with: { class: "fr-header__body" } do
+          with_tag "div", with: { class: "fr-header__logo" } do
+            with_tag "p", with: { class: "fr-logo" }, text: "Ministère du Travail"
+          end
+          with_tag "div", with: { class: "fr-header__navbar" } do
+            with_tag "button", text: /Rechercher/
+            without_tag "button", text: /Menu/
+          end
+          with_tag "div", with: { class: "fr-header__tools" } do
+            without_tag "div", with: { class: "fr-header__tools-links" }
+            with_tag "div", with: { class: "fr-header__search" } do
+              with_tag "div", with: { class: "fr-search-bar" } do
+                with_tag "input", with: { placeholder: "Rechercher une entreprise" }
+              end
+            end
+          end
+        end
+        without_tag "div", with: { class: "fr-header__menu" }
+      end
+    end
+  end
+  # rubocop:enable Rails/OutputSafety
+end


### PR DESCRIPTION
I created 3 subcomponents : 

- `ToolLinkComponent`
- `DirectLinkComponent`
- `DirectLinkDropdownComponent` (that is composed of many of the previous one)

I also used a polymorphic slot for direct_links with the types option, cf [viewcomponent doc](https://viewcomponent.org/guide/slots.html#polymorphic-slots) 

This allows calling : 
- `c.with_direct_link_simple title: "thing", path: "#here"`
- or `c.with_direct_link_dropdown title: "other thing" do |cc| ...`

and preserve the order when displaying them in the component view with `direct_links.each do |direct_link|`

The suffix `_simple` is quite unfortunate but I could not find a way to not have this suffix for the default case.

![Screenshot 2023-03-13 at 16-06-26 En-tête - Header - Composants Rails ViewComponent pour le Système de Design de lʼÉtat](https://user-images.githubusercontent.com/883348/224742786-c242ef95-9760-45be-9e0f-7f63d0ba4843.png)

