### PR TITLE
component: Tabs

### DIFF
--- a/app/components/dsfr_component/tabs_component.html.erb
+++ b/app/components/dsfr_component/tabs_component.html.erb
@@ -1,0 +1,12 @@
+<%= tag.div(**html_attributes) do %>
+  <ul class="fr-tabs__list" role="tablist" aria-label="<%= label %>">
+    <% tabs.each do |tab| %>
+      <li role="presentation">
+        <%= tab.nav_item %>
+      </li>
+    <% end %>
+  </ul>
+  <% tabs.each do |tab| %>
+    <%= tab %>
+  <% end %>
+<% end %>

--- a/app/components/dsfr_component/tabs_component.rb
+++ b/app/components/dsfr_component/tabs_component.rb
@@ -1,0 +1,34 @@
+class DsfrComponent::TabsComponent < DsfrComponent::Base
+  renders_many :tabs, "DsfrComponent::TabsComponent::TabComponent"
+
+  # @param label [String] Le nom du système d’onglets, sera uniquement affiché comme aria-label (optionnel)
+  def initialize(label: nil, classes: [], html_attributes: {})
+    @label = label
+    @tabs = []
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  def call
+    raise ArgumentError, "You must provide at least one tab" if tabs.empty?
+
+    tag.div(**html_attributes) do
+      tag.ul(class: 'fr-tabs__list', role: "tablist", "aria-label": label) do
+        tabs.map do |tab|
+          tag.li(role: "presentation") do
+            tab.nav_item
+          end
+        end.join.html_safe
+      end +
+        tabs.map(&:call).join.html_safe
+    end
+  end
+
+private
+
+  attr_reader :label
+
+  def default_attributes
+    { class: 'fr-tabs' }
+  end
+end

--- a/app/components/dsfr_component/tabs_component.rb
+++ b/app/components/dsfr_component/tabs_component.rb
@@ -9,21 +9,6 @@ class DsfrComponent::TabsComponent < DsfrComponent::Base
     super(classes: classes, html_attributes: html_attributes)
   end
 
-  def call
-    raise ArgumentError, "You must provide at least one tab" if tabs.empty?
-
-    tag.div(**html_attributes) do
-      tag.ul(class: 'fr-tabs__list', role: "tablist", "aria-label": label) do
-        tabs.map do |tab|
-          tag.li(role: "presentation") do
-            tab.nav_item
-          end
-        end.join.html_safe
-      end +
-        tabs.map(&:call).join.html_safe
-    end
-  end
-
 private
 
   attr_reader :label

--- a/app/components/dsfr_component/tabs_component/tab_component.rb
+++ b/app/components/dsfr_component/tabs_component/tab_component.rb
@@ -1,0 +1,54 @@
+class DsfrComponent::TabsComponent::TabComponent < DsfrComponent::Base
+  # @param title [String] Le titre de l’onglet affiché dans la barre d’onglets
+  # @param active [Boolean] Définit si l’onglet est actif ou non
+  # @param path [String] (optionnel) chemin vers lequel l’onglet pointe, utilisable avec Turbo Drive, transforme le bouton en lien, avec une turbo action `advance`
+  def initialize(title:, active: false, path: nil, classes: [], html_attributes: {})
+    @title = title
+    @active = active
+    @path = path
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  def nav_id
+    @nav_id ||= "tab-#{title_slug}-nav"
+  end
+
+  def panel_id
+    @panel_id ||= "tab-#{title_slug}-panel"
+  end
+
+  def nav_item
+    path ? nav_link : nav_button
+  end
+
+  def call
+    tag.div(**html_attributes) { content }
+  end
+
+private
+
+  attr_reader :title, :active, :path
+
+  def default_attributes
+    classes = ['fr-tabs__panel']
+    classes << "fr-tabs__panel--selected" if active
+    { id: panel_id, class: classes, role: 'tabpanel', "aria-labelledby": nav_id }
+  end
+
+  def title_slug
+    @title_slug ||= title.parameterize
+  end
+
+  def nav_button
+    tag.button(title, **nav_html_attributes)
+  end
+
+  def nav_link
+    tag.a(title, href: path, data: { turbo_action: "advance" }, **nav_html_attributes)
+  end
+
+  def nav_html_attributes
+    { id: nav_id, class: 'fr-tabs__tab', role: 'tab', "aria-selected": active ? "true" : "false", "aria-controls": panel_id }
+  end
+end

--- a/app/components/dsfr_component/tabs_component/tab_component.rb
+++ b/app/components/dsfr_component/tabs_component/tab_component.rb
@@ -2,10 +2,12 @@ class DsfrComponent::TabsComponent::TabComponent < DsfrComponent::Base
   # @param title [String] Le titre de l’onglet affiché dans la barre d’onglets
   # @param active [Boolean] Définit si l’onglet est actif ou non
   # @param path [String] (optionnel) chemin vers lequel l’onglet pointe, utilisable avec Turbo Drive, transforme le bouton en lien, avec une turbo action `advance`
-  def initialize(title:, active: false, path: nil, classes: [], html_attributes: {})
+  # @param icon [String] (optionnel) icône affichée à gauche du titre de l’onglet (sans le préfixe `fr-icon-`)
+  def initialize(title:, active: false, path: nil, icon: nil, classes: [], html_attributes: {})
     @title = title
     @active = active
     @path = path
+    @icon = icon
 
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -28,7 +30,7 @@ class DsfrComponent::TabsComponent::TabComponent < DsfrComponent::Base
 
 private
 
-  attr_reader :title, :active, :path
+  attr_reader :title, :active, :path, :icon
 
   def default_attributes
     classes = ['fr-tabs__panel']
@@ -49,6 +51,8 @@ private
   end
 
   def nav_html_attributes
-    { id: nav_id, class: 'fr-tabs__tab', role: 'tab', "aria-selected": active ? "true" : "false", "aria-controls": panel_id }
+    classes = ["fr-tabs__tab"]
+    classes += ["fr-icon-#{icon}", "fr-tabs__tab--icon-left"] if icon.present?
+    { id: nav_id, class: classes, role: 'tab', "aria-selected": active ? "true" : "false", "aria-controls": panel_id }
   end
 end

--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -14,6 +14,7 @@ module DsfrComponentsHelper
     dsfr_header_tool_link: 'DsfrComponent::HeaderComponent::ToolLinkComponent',
     dsfr_header_direct_link: 'DsfrComponent::HeaderComponent::DirectLinkComponent',
     dsfr_header_direct_dropdown_link: 'DsfrComponent::HeaderComponent::DirectLinkDropdownComponent',
+    dsfr_tabs: 'DsfrComponent::TabsComponent',
     # DO NOT REMOVE: new component mapping here
   }.freeze
   HELPER_NAME_TO_CLASS_NAME.each do |name, klass|

--- a/guide/content/components/header.haml
+++ b/guide/content/components/header.haml
@@ -45,5 +45,4 @@ title: En-tête - Header
   :markdown
     Cet exemple regroupe toutes les fonctionnalités d’un header.
 
-.fr-mt-4w
-  = render '/partials/related-info.haml', links: dsfr_component_doc_link("Header", "en-tete")
+= render '/partials/related-info.haml', links: dsfr_component_doc_link("Header", "en-tete")

--- a/guide/content/components/tabs.haml
+++ b/guide/content/components/tabs.haml
@@ -13,6 +13,10 @@ title: Tabs
   :markdown
     Le rendu de base du TabsComponent
 
+= render "/partials/example.haml", caption: "Onglets avec des icônes", code: tabs_with_icons do
+  :markdown
+    Vous pouvez utiliser des icônes pour illustrer les onglets.
+
 = render "/partials/example.haml", caption: "Onglets avec des liens", code: tabs_with_links do
   :markdown
     Les boutons de navigation des onglets peuvent être des transformés en liens vers d'autres pages en utilisant le paramètre `path`.

--- a/guide/content/components/tabs.haml
+++ b/guide/content/components/tabs.haml
@@ -1,0 +1,24 @@
+---
+title: Tabs
+---
+
+.fr-text-wrap
+  :markdown
+    Le composant onglet permet aux utilisateurs de naviguer dans différentes sections de contenu au sein d’une même page.
+
+    Le système d'onglet aide à regrouper différents contenus dans un espace limité et permet de diviser un contenu dense en sections accessibles individuellement afin de faciliter la lecture pour l'utilisateur.
+
+
+= render '/partials/example.haml', caption: "Vue d'ensemble", code: tabs_default do
+  :markdown
+    Le rendu de base du TabsComponent
+
+= render "/partials/example.haml", caption: "Onglets avec des liens", code: tabs_with_links do
+  :markdown
+    Les boutons de navigation des onglets peuvent être des transformés en liens vers d'autres pages en utilisant le paramètre `path`.
+
+    Cela permet entre-autres d’utiliser Turbo Drive pour naviguer entre les onglets.
+    Chaque page affiche uniquement un onglet actif avec son contenu et les liens vers les autres onglets.
+    L’onglet actif n’a pas besoin d’avoir de lien, il peut rester un bouton.
+
+.fr-mt-8w= render('/partials/related-info.haml', links: dsfr_component_doc_link("Tabs", "onglets"))

--- a/guide/content/components/tabs.haml
+++ b/guide/content/components/tabs.haml
@@ -25,4 +25,4 @@ title: Tabs
     Chaque page affiche uniquement un onglet actif avec son contenu et les liens vers les autres onglets.
     L’onglet actif n’a pas besoin d’avoir de lien, il peut rester un bouton.
 
-.fr-mt-8w= render('/partials/related-info.haml', links: dsfr_component_doc_link("Tabs", "onglets"))
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("Tabs", "onglets"))

--- a/guide/content/components/tile.haml
+++ b/guide/content/components/tile.haml
@@ -29,5 +29,4 @@ title: Tuile (Tile)
 
     Le niveau par défaut est `4`, vous pouvez l’augmenter ou le baisser selon votre contexte.
 
-.fr-mt-4w
-  = render('/partials/related-info.haml', links: dsfr_component_doc_link("Tuile"))
+= render('/partials/related-info.haml', links: dsfr_component_doc_link("Tuile"))

--- a/guide/layouts/partials/related-info.haml
+++ b/guide/layouts/partials/related-info.haml
@@ -1,7 +1,8 @@
-%h2
-  Plus d'informations
+.fr-mt-4w
+  %h2
+    Plus d'informations
 
-%ul
-  - links.each do |text, link|
-    %li
-      = link_to text, link, target: '_blank', rel: 'noopener'
+  %ul
+    - links.each do |text, link|
+      %li
+        = link_to text, link, target: '_blank', rel: 'noopener'

--- a/guide/lib/examples/tabs_helpers.rb
+++ b/guide/lib/examples/tabs_helpers.rb
@@ -1,0 +1,23 @@
+module Examples
+  module TabsHelpers
+    def tabs_default
+      <<~RAW
+        = dsfr_tabs do |tabs|
+          = tabs.tab title: "Onglet 1", active: true do
+            %p Contenu de l’onglet 1
+          = tabs.tab title: "Onglet 2" do
+            %p Contenu de l’onglet 2
+      RAW
+    end
+
+    def tabs_with_links
+      <<~RAW
+        = dsfr_tabs do |tabs|
+          = tabs.tab title: "Première page", path: "#onglet-1"
+          = tabs.tab title: "Deuxième page", active: true do
+            %p Contenu de l’onglet 2
+          = tabs.tab title: "Troisième page", path: "#onglet-3"
+      RAW
+    end
+  end
+end

--- a/guide/lib/examples/tabs_helpers.rb
+++ b/guide/lib/examples/tabs_helpers.rb
@@ -3,20 +3,32 @@ module Examples
     def tabs_default
       <<~RAW
         = dsfr_tabs do |tabs|
-          = tabs.tab title: "Onglet 1", active: true do
+          - tabs.tab title: "Onglet 1", active: true do
             %p Contenu de l’onglet 1
-          = tabs.tab title: "Onglet 2" do
+          - tabs.tab title: "Onglet 2" do
             %p Contenu de l’onglet 2
+      RAW
+    end
+
+    def tabs_with_icons
+      <<~RAW
+        = dsfr_tabs do |tabs|
+          - tabs.tab title: "Comment ça marche ?", icon: "info-fill" do
+            %p Ça marche bien
+          - tabs.tab title: "Contact", icon: "mail-line" do
+            %p Contactez-nous par email
+          - tabs.tab title: "Support", active: true, icon: "settings-5-line" do
+            %p Support technique
       RAW
     end
 
     def tabs_with_links
       <<~RAW
         = dsfr_tabs do |tabs|
-          = tabs.tab title: "Première page", path: "#onglet-1"
-          = tabs.tab title: "Deuxième page", active: true do
+          - tabs.tab title: "Première page", path: "#onglet-1"
+          - tabs.tab title: "Deuxième page", active: true do
             %p Contenu de l’onglet 2
-          = tabs.tab title: "Troisième page", path: "#onglet-3"
+          - tabs.tab title: "Troisième page", path: "#onglet-3"
       RAW
     end
   end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -48,3 +48,4 @@ use_helper Examples::StepperHelpers
 use_helper Examples::ButtonHelpers
 use_helper Examples::ModalHelpers
 use_helper Examples::HeaderHelpers
+use_helper Examples::TabsHelpers

--- a/spec/components/dsfr_component/tabs_component_spec.rb
+++ b/spec/components/dsfr_component/tabs_component_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe(DsfrComponent::TabsComponent, type: :component) do
   context "with basic usage" do
     subject! do
       render_inline(described_class.new) do |tabs|
-        render_inline(tabs.tab(title: "Onglet 1", active: true)) do
+        tabs.tab(title: "Onglet 1", active: true) do
           "contenu premier onglet"
         end
-        render_inline(tabs.tab(title: "Onglet 2")) do
+        tabs.tab(title: "Onglet 2") do
           "contenu deuxième onglet"
         end
       end
@@ -37,14 +37,55 @@ RSpec.describe(DsfrComponent::TabsComponent, type: :component) do
     end
   end
 
+  context "with icons" do
+    subject! do
+      render_inline(described_class.new) do |tabs|
+        tabs.tab(title: "Comment ça marche ?", icon: "info-line") do
+          "Ça marche bien"
+        end
+        tabs.tab(title: "Contact", icon: "mail-line") do
+          "Contactez-nous par email"
+        end
+        tabs.tab(title: "Support", active: true, icon: "settings-5-line") do
+          "Support technique"
+        end
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:div, with: { class: "fr-tabs" }) do
+        with_tag(:ul, with: { class: "fr-tabs__list" }) do
+          with_tag \
+            :button,
+            with: { class: "fr-tabs__tab fr-icon-info-line fr-tabs__tab--icon-left", role: "tab",
+                    "aria-selected": "false", "aria-controls": "tab-comment-ca-marche-panel",
+                    id: "tab-comment-ca-marche-nav" },
+            text: /Comment ça marche/
+          with_tag \
+            :button,
+            with: { class: "fr-tabs__tab fr-icon-mail-line fr-tabs__tab--icon-left", role: "tab",
+                    "aria-selected": "false", "aria-controls": "tab-contact-panel",
+                    id: "tab-contact-nav" },
+            text: /Contact/
+          with_tag \
+            :button,
+            with: { class: "fr-tabs__tab fr-icon-settings-5-line fr-tabs__tab--icon-left", role: "tab",
+                    "aria-selected": "true", "aria-controls": "tab-support-panel",
+                    id: "tab-support-nav" },
+            text: /Support/
+        end
+      end
+    end
+  end
+
   context "with links instead of buttons" do
     subject! do
       render_inline(described_class.new) do |tabs|
-        render_inline tabs.tab(title: "Onglet 1", path: "/onglet-1")
-        render_inline tabs.tab(title: "Onglet 2", active: true) do
+        tabs.tab(title: "Onglet 1", path: "/onglet-1")
+        tabs.tab(title: "Onglet 2", active: true) do
           "contenu deuxième onglet chargé"
         end
-        render_inline tabs.tab(title: "Onglet 3", path: "/onglet-3")
+        tabs.tab(title: "Onglet 3", path: "/onglet-3")
       end
     end
 

--- a/spec/components/dsfr_component/tabs_component_spec.rb
+++ b/spec/components/dsfr_component/tabs_component_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe(DsfrComponent::TabsComponent, type: :component) do
+  context "with basic usage" do
+    subject! do
+      render_inline(described_class.new) do |tabs|
+        render_inline(tabs.tab(title: "Onglet 1", active: true)) do
+          "contenu premier onglet"
+        end
+        render_inline(tabs.tab(title: "Onglet 2")) do
+          "contenu deuxième onglet"
+        end
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:div, with: { class: "fr-tabs" }) do
+        with_tag(:ul, with: { class: "fr-tabs__list" }) do
+          with_tag \
+            :button,
+            with: { class: "fr-tabs__tab", role: "tab", "aria-selected": "true", "aria-controls": "tab-onglet-1-panel", id: "tab-onglet-1-nav" },
+            text: /Onglet 1/
+          with_tag \
+            :button,
+            with: { class: "fr-tabs__tab", role: "tab", "aria-selected": "false", "aria-controls": "tab-onglet-2-panel", id: "tab-onglet-2-nav" },
+            text: /Onglet 2/
+        end
+        with_tag \
+          :div,
+          with: { class: "fr-tabs__panel fr-tabs__panel--selected", role: "tabpanel", id: "tab-onglet-1-panel", "aria-labelledby": "tab-onglet-1-nav" },
+          text: /contenu premier onglet/
+        with_tag \
+          :div,
+          with: { class: "fr-tabs__panel", role: "tabpanel", id: "tab-onglet-2-panel", "aria-labelledby": "tab-onglet-2-nav" },
+          text: /contenu deuxième onglet/
+      end
+    end
+  end
+
+  context "with links instead of buttons" do
+    subject! do
+      render_inline(described_class.new) do |tabs|
+        render_inline tabs.tab(title: "Onglet 1", path: "/onglet-1")
+        render_inline tabs.tab(title: "Onglet 2", active: true) do
+          "contenu deuxième onglet chargé"
+        end
+        render_inline tabs.tab(title: "Onglet 3", path: "/onglet-3")
+      end
+    end
+
+    it "renders correctly" do
+      expect(rendered_content).to have_tag(:div, with: { class: "fr-tabs" }) do
+        with_tag(:ul, with: { class: "fr-tabs__list" }) do
+          with_tag \
+            :a,
+            with: { href: "/onglet-1", "data-turbo-action": "advance", class: "fr-tabs__tab", role: "tab", "aria-selected": "false", "aria-controls": "tab-onglet-1-panel",
+                    id: "tab-onglet-1-nav" },
+            text: /Onglet 1/
+          with_tag \
+            :button,
+            with: { class: "fr-tabs__tab", role: "tab", "aria-selected": "true", "aria-controls": "tab-onglet-2-panel",
+                    id: "tab-onglet-2-nav" },
+            text: /Onglet 2/
+          with_tag \
+            :a,
+            with: { href: "/onglet-3", "data-turbo-action": "advance", class: "fr-tabs__tab", role: "tab", "aria-selected": "false", "aria-controls": "tab-onglet-3-panel",
+                    id: "tab-onglet-3-nav" },
+            text: /Onglet 3/
+        end
+        with_tag \
+          :div,
+          with: { class: "fr-tabs__panel", role: "tabpanel", id: "tab-onglet-1-panel", "aria-labelledby": "tab-onglet-1-nav" }
+        with_tag \
+          :div,
+          with: { class: "fr-tabs__panel fr-tabs__panel--selected", role: "tabpanel", id: "tab-onglet-2-panel", "aria-labelledby": "tab-onglet-2-nav" }
+        with_tag \
+          :div,
+          with: { class: "fr-tabs__panel", role: "tabpanel", id: "tab-onglet-3-panel", "aria-labelledby": "tab-onglet-3-nav" }
+      end
+    end
+  end
+end


### PR DESCRIPTION
fix #87

![image](https://user-images.githubusercontent.com/883348/225896955-76352e2e-8def-4659-a528-e9c5314d9cfb.png)

## 1. Component naming

Is `TabsComponent` a good name for the main component? The plural feels weird. We could also name it something like `TabSectionComponent` 

## 2. API & Subcomponent split

I splat out a `DsfrComponent::TabsComponent::TabComponent` that is slightly weird : 

- it’s main `call` function returns the HTML for the tab panel
- it has a `nav_item` function returns the HTML for the nav item (button or link)

I feel like the `nav_item` method is misplaced but I don’t really know how to make it better. 

We could maybe split out the individual `TabComponent` into two sub-sub-components `TabNavItemComponent` and `TabPanelComponent` but calling it would be a bit verbose: 

```haml
= dsfr_tabs do |tabs|
  = tabs.with_tab do |tab|
    = tab.with_nav_item(title: "Premier onglet", active: true)
    = tab.with_panel do 
      Contenu du premier onglet
  ...
```

I feel like we’d be exposing too much of the internal complexity that way, but the code would be nicer, wdyt?

## 3. HTML id uniqueness

We need an html `id` for the panel so that the JS behaviour works

I’m currently auto-generating it with `parameterize(title)`. This has the benefit of giving readable and predictable IDs that can be used as anchors. However it can generate conflicts if you have two tabs with the same title, which is weird unless you have two tab systems on a single page - which could happen.

The alternatives would be to require the user to passe the HTML id himself or to add a `SecureRandom.hex(4)` suffix. wdyt?
