### PR TITLE
Ajout d'un logo opérateur horizontal dans l'en-tête

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
     nenv (0.3.0)
     nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -275,6 +277,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.5.4-arm64-darwin)
+    sqlite3 (1.5.4-x86_64-darwin)
     sqlite3 (1.5.4-x86_64-linux)
     stringio (3.0.4)
     sysexits (1.2.0)
@@ -300,6 +303,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/app/components/dsfr_component/header_component.html.erb
+++ b/app/components/dsfr_component/header_component.html.erb
@@ -8,6 +8,10 @@
               <p class="fr-logo"><%= logo_text %></p>
             </div>
 
+            <% if operator_image? %>
+              <%= operator_image %>
+            <% end %>
+
             <% if search? || tool_links? || direct_links? %>
               <div class="fr-header__navbar">
                 <% if search? %>
@@ -25,14 +29,16 @@
             <% end %>
           </div>
 
-          <div class="fr-header__service">
-            <a href="/" title="Accueil - <%= title %>">
-              <p class="fr-header__service-title"><%= title %></p>
-            </a>
-            <% if tagline %>
-              <p class="fr-header__service-tagline"><%= tagline %></p>
-            <% end %>
-          </div>
+          <% if title %>
+            <div class="fr-header__service">
+              <a href="/" title="Accueil - <%= title %>">
+                <p class="fr-header__service-title"><%= title %></p>
+              </a>
+              <% if tagline %>
+                <p class="fr-header__service-tagline"><%= tagline %></p>
+              <% end %>
+            </div>
+          <% end %>
         </div>
 
         <% if tool_links? || search? %>

--- a/app/components/dsfr_component/header_component.rb
+++ b/app/components/dsfr_component/header_component.rb
@@ -1,5 +1,6 @@
 class DsfrComponent::HeaderComponent < DsfrComponent::Base
   renders_one :search
+  renders_one :operator_image, "DsfrComponent::HeaderComponent::OperatorImageComponent"
   renders_many :tool_links, "DsfrComponent::HeaderComponent::ToolLinkComponent"
   renders_many :direct_links, types: {
     simple: "DsfrComponent::HeaderComponent::DirectLinkComponent",
@@ -9,7 +10,7 @@ class DsfrComponent::HeaderComponent < DsfrComponent::Base
   # @param logo_text [String] Ce texte obligatoire sera affiché en dessous de la Marianne et au dessus de la devise française. C’est généralement un nom de ministère ou d’administration.
   # @param title [String] Le nom du service numérique, titre principal du site.
   # @param tagline [String] La description du service numérique, sous-titre du site (optionnelle).
-  def initialize(logo_text:, title:, tagline: nil, classes: [], html_attributes: {})
+  def initialize(logo_text:, title: nil, tagline: nil, classes: [], html_attributes: {})
     @logo_text = logo_text
     @title = title
     @tagline = tagline

--- a/app/components/dsfr_component/header_component/operator_image_component.rb
+++ b/app/components/dsfr_component/header_component/operator_image_component.rb
@@ -1,0 +1,28 @@
+class DsfrComponent::HeaderComponent::OperatorImageComponent < DsfrComponent::Base
+  # @param title [String] Le title du lien vers la page d'accueil du site
+  # @param src [String] L'attribut src qui sera passé au tag img
+  # @param alt [String] Le texte alternatif qui sera passé au tag img. Il doit impérativement contenir le texte présent dans l’image.
+  def initialize(title:, src:, alt:, classes: [], html_attributes: {})
+    @title = title
+    @src = src
+    @alt = alt
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  def call
+    tag.div(class: "fr-header__operator") do
+      tag.a(href: "/", title: title) do
+        tag.img(class: "fr-responsive-img", src: src, alt: alt, style: "max-width:9.0625rem;")
+      end
+    end
+  end
+
+  def default_attributes
+    {}
+  end
+
+private
+
+  attr_reader :title, :src, :alt
+end

--- a/guide/content/components/header.haml
+++ b/guide/content/components/header.haml
@@ -14,6 +14,11 @@ title: En-tête - Header
   :markdown
     Le texte du logo peut être sur deux lignes en ajoutant une classe CSS personnalisée
 
+= render '/partials/example.haml', caption: "En-tête avec logo horizontal", code: header_with_horizontal_logo do
+  :markdown
+    Un header peut présenter un logo horizontal.
+    L’alternative textuelle du logo (attribut alt) doit impérativement contenir le texte présent dans l’image.
+
 = render '/partials/example.haml', caption: "En-tête avec des accès rapides", code: header_with_tool_links do
   :markdown
     Un header peut présenter des liens d’accès rapide (*tool links* dans le code).

--- a/guide/lib/examples/header_helpers.rb
+++ b/guide/lib/examples/header_helpers.rb
@@ -15,6 +15,15 @@ module Examples
       HEADER
     end
 
+    def header_with_horizontal_logo
+      <<~HEADER
+        = dsfr_header logo_text: "Ministère du Travail", title: "Égapro" do |header|
+          - header.with_operator_image title: "beta.gouv.fr", src: "https://beta.gouv.fr/assets/additional/images/logo-betagouvfr.svg", alt: "logo de beta.gouv.fr"
+          - header.with_tool_link title: "Comment ça marche", path: "#comment-ca-marche"
+          - header.with_tool_link title: "Contact", path: "#contact", classes: ["fr-icon-mail-line"]
+      HEADER
+    end
+
     def header_with_tool_links
       <<~HEADER
         = dsfr_header logo_text: "Ministère du Travail", title: "Égapro", tagline: "Indice de parité professionelle" do |header|


### PR DESCRIPTION
Cette PR ajoute la possibilité d'avoir un logo opérateur horizontal dans l'en tête (header). Ça va nous être utile pour rdv.anct.gouv.fr

Au passage, on rend aussi l'attribut `title` optionnel pour l'en-tête (conformément à la doc du dsfr), ce qui nous sera aussi utile.

L'exemple dans le guide ressemble à ça : 
<img width="1267" alt="Screenshot 2023-06-19 at 10 15 37" src="https://github.com/betagouv/dsfr-view-components/assets/1840367/ef962a72-9382-4f25-892b-0f8b741079a6">
