### PR TITLE
ajoute un role ARIA à la div wrapper de modale du header

### DIFF
--- a/app/components/dsfr_component/header_component.html.erb
+++ b/app/components/dsfr_component/header_component.html.erb
@@ -74,7 +74,7 @@
   </div>
 
   <% if tool_links? || direct_links? %>
-    <div class="fr-header__menu fr-modal" id="modal-header-menu" aria-labelledby="button-header-menu">
+    <div class="fr-header__menu fr-modal" id="modal-header-menu" aria-labelledby="button-header-menu" role="navigation">
       <div class="fr-container">
         <button class="fr-btn--close fr-btn" aria-controls="modal-header-menu" title="Fermer">
           Fermer


### PR DESCRIPTION
Tel quel, le DOM du composant footer ne passe pas la batterie de specs de la gem AXE core sans configuration particulière

Le problème vient de la div wrapper de la modale de menu qui utilise un `aria-labelledby` alors qu’elle n’a pas de role ARIA. 
Cela semble être une faute et c’est remonté comme `serious` : 

```sh
       1) aria-allowed-attr: Elements must only use allowed ARIA attributes (serious)
           https://dequeuniversity.com/rules/axe/4.3/aria-allowed-attr?application=axeAPI
           The following 1 node violate this rule:

               Selector: #modal-header-menu
               HTML: <div class="fr-header__menu fr-modal" id="modal-header-menu" aria-labelledby="button-header-menu" data-fr-js-modal="true" data-fr-js-header-modal="true">
               Fix all of the following:
               - ARIA attribute cannot be used, add a role attribute or use a different element: aria-labelledby
```

cf la règle un peu dure à lire https://dequeuniversity.com/rules/axe/4.3/aria-allowed-attr?application=axeAPI

J’en déduis que pour utiliser `aria-labelledby` il faut un `role`, ce qu je rajoute ici. 
J’ai envisagé d’utiliser un `<nav>` plutôt qu’un rôle `nav` mais il y a déjà une nav nestée dans la modale donc je trouve ça un peu bizarre
J’ai aussi envisagé d’utiliser le rôle `alertdialog` mais ça ne semble pas correspondre à un menu de navigation.