### PR TITLE
fix GitHub Actions CI with ruby 2 versions and bundler

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           RAILS_VERSION: ${{ matrix.rails }}
         run: |
-          gem install bundler
+          gem install bundler ${{ startsWith(matrix.ruby, '2') && '-v 2' }}
           bundle install --jobs 4 --retry 3
 
       - name: Run RSpec


### PR DESCRIPTION
bundler v3 n’est pas compatible avec ruby 2, il faut forcer l’installation de la version 2