### PR TITLE
MàJ de la CI pour utiliser les actions de déploiement des pages GH officielles

### DIFF
--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feature/use-gh-actions-deploy-pages
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feature/use-gh-actions-deploy-pages
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Deploy Guide
+    name: Build & Upload static site
     steps:
       - uses: actions/checkout@v4
       - name: Install Ruby & gems
@@ -20,12 +20,12 @@ jobs:
           node-version: 18
       - run: make build-guide
   deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -4,26 +4,27 @@ on:
     branches:
       - main
 jobs:
-  rspec:
+  build:
     runs-on: ubuntu-latest
     name: Deploy Guide
     steps:
       - uses: actions/checkout@v2
-
       - name: Install Ruby & gems
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: 3.1.2
-
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-
       - run: make build-guide
-
-      - name: Deploy to GH Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          publish_dir: ./guide/output
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -26,6 +26,10 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           node-version: 18
       - run: make build-guide
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./guide/output
+
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest


### PR DESCRIPTION
On utilisait https://github.com/peaceiris/actions-gh-pages 
On peut maintenant utiliser les actions « officielles » de GH cf https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#usage

ça ne devrait rien changer