### PR TITLE
MàJ ruby 3.1 vers 3.3 dans le readme et l’action GH de deploiement des pages

### DIFF
--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -14,7 +14,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.1.2
+          ruby-version: 3.3.6
 
       - uses: actions/setup-node@v3
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ and [back to top links](https://govuk-components.netlify.app/helpers/back-to-top
 Nous conseillons d'utiliser [rbenv](https://github.com/rbenv/rbenv) pour gérer vos versions de ruby :
 
 ```sh
-rbenv local 3.1.2
+rbenv local 3.3.6
 rbenv install
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gem](https://img.shields.io/gem/dt/dsfr-view-components?logo=rubygems)](https://rubygems.org/gems/dsfr-view-components)
 [![GitHub license](https://img.shields.io/github/license/betagouv/dsfr-view-components)](https://github.com/betagouv/dsfr-view-components/blob/main/LICENSE)
 [![Rails](https://img.shields.io/badge/Rails-6.1.5%20%E2%95%B1%207.0.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-2.7.6%20%20%E2%95%B1%203.0.3%20%20%E2%95%B1%203.1.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Ruby](https://img.shields.io/badge/Ruby-3.2.6%20%20%E2%95%B1%203.3.6-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 [![Design Système de lʼÉtat](https://img.shields.io/badge/Design%20Système%20de%20lʼÉtat-1.8.4-brightgreen)](https://www.systeme-de-design.gouv.fr/)
 


### PR DESCRIPTION
on indiquait encore d’utiliser ruby 3.1 dans le readme, et on utilisait 3.1 dans le job CI de deploiement des pages.

Cette PR corrige le bug de deploiement des pages cf ce run où j’avais activé sur cette branche pour vérifier https://github.com/betagouv/dsfr-view-components/actions/runs/12545089263/job/34978748007