### PR TITLE
Uniformisation des titres dans le guide

### DIFF
--- a/guide/content/components/accordion.haml
+++ b/guide/content/components/accordion.haml
@@ -1,5 +1,5 @@
 ---
-title: Accordéon
+title: Accordéon - Accordion
 ---
 
 .fr-text-wrap

--- a/guide/content/components/alert.haml
+++ b/guide/content/components/alert.haml
@@ -1,5 +1,5 @@
 ---
-title: Alerte
+title: Alerte - Alert
 ---
 
 %p

--- a/guide/content/components/badge.haml
+++ b/guide/content/components/badge.haml
@@ -1,5 +1,5 @@
 ---
-title: Badge
+title: Badge - Badge
 ---
 
 .fr-text-wrap

--- a/guide/content/components/button.haml
+++ b/guide/content/components/button.haml
@@ -1,5 +1,5 @@
 ---
-title: Button
+title: Bouton - Button
 ---
 
 .fr-text-wrap

--- a/guide/content/components/modal.haml
+++ b/guide/content/components/modal.haml
@@ -1,5 +1,5 @@
 ---
-title: Modal
+title: Modale - Modal
 ---
 
 .fr-text-wrap

--- a/guide/content/components/tabs.haml
+++ b/guide/content/components/tabs.haml
@@ -1,5 +1,5 @@
 ---
-title: Tabs
+title: Onglet - Tab
 ---
 
 .fr-text-wrap

--- a/guide/content/components/tag.haml
+++ b/guide/content/components/tag.haml
@@ -1,5 +1,5 @@
 ---
-title: Tag
+title: Tag - Tag
 ---
 
 .fr-text-wrap

--- a/guide/content/components/tile.haml
+++ b/guide/content/components/tile.haml
@@ -1,5 +1,5 @@
 ---
-title: Tuile (Tile)
+title: Tuile - Tile
 ---
 
 .fr-text-wrap


### PR DESCRIPTION
Dans le guide, tous les titres de composants ne sont pas uniformes.

Cette PR vise à utiliser la même nomenclature pour toutes les pages, et à suivre les noms de la documentation officielle du DSFR.

## Avant 

<img width="429" alt="image" src="https://github.com/user-attachments/assets/3214518d-d1de-4bfc-b686-48115dbcbb1c" />

## Après 

<img width="407" alt="image" src="https://github.com/user-attachments/assets/b9b7bb42-c3d0-4da1-a350-f62bda47036d" />
