### PR TITLE
Fix: liens vers la documentation du composant

### DIFF
--- a/lib/generators/dsfr_component/templates/component.haml.erb
+++ b/lib/generators/dsfr_component/templates/component.haml.erb
@@ -10,4 +10,4 @@ title: <%= name %>
   :markdown
     Le rendu de base du <%= name %>Component
 
-= render('/partials/related-info.haml', links: dsfr_component_doc_link("<%= name %>"))
+= render('/partials/related-info.haml', links: dsfr_component_doc_links("doc-id", "storybook-id"))


### PR DESCRIPTION
Lorsque nous avons changé la signature de la méthode `dsfr_component_doc_link` en `dsfr_component_doc_links` dans #214 nous avons oublié de changer le template utilisé par le générateur.