### PR TITLE
Ajout du composant d’information importante (Notice)

### DIFF
--- a/app/components/dsfr_component/notice_component.html.erb
+++ b/app/components/dsfr_component/notice_component.html.erb
@@ -1,0 +1,14 @@
+<%= tag.div(**html_attributes) do %>
+  <div class="fr-container">
+    <div class="fr-notice__body">
+      <%= tag.send(markup_tag) do %>
+        <span class="fr-notice__title"><%= title %></span>
+        <span class="fr-notice__desc"><%= description %></span>
+        <%= link_tag %>
+      <% end %>
+      <% if dismissible %>
+        <button onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" title="Masquer le message" type="button" class="fr-btn--close fr-btn">Masquer le message</button>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/dsfr_component/notice_component.html.erb
+++ b/app/components/dsfr_component/notice_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div(**html_attributes) do %>
   <div class="fr-container">
     <div class="fr-notice__body">
-      <%= tag.send(markup_tag) do %>
+      <%= tag.send(description_tag) do %>
         <span class="fr-notice__title <%= icon_class %>"><%= title %></span>
         <span class="fr-notice__desc"><%= description %></span>
         <%= link_tag %>

--- a/app/components/dsfr_component/notice_component.html.erb
+++ b/app/components/dsfr_component/notice_component.html.erb
@@ -2,12 +2,12 @@
   <div class="fr-container">
     <div class="fr-notice__body">
       <%= tag.send(markup_tag) do %>
-        <span class="fr-notice__title"><%= title %></span>
+        <span class="fr-notice__title <%= icon_class %>"><%= title %></span>
         <span class="fr-notice__desc"><%= description %></span>
         <%= link_tag %>
       <% end %>
       <% if dismissible %>
-        <button onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" title="Masquer le message" type="button" class="fr-btn--close fr-btn">Masquer le message</button>
+        <button onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" title="<%= @dismiss_label %>" type="button" class="fr-btn--close fr-btn"><%= @dismiss_label %></button>
       <% end %>
     </div>
   </div>

--- a/app/components/dsfr_component/notice_component.rb
+++ b/app/components/dsfr_component/notice_component.rb
@@ -7,27 +7,27 @@ module DsfrComponent
 
     WEATHER_ICONS = %w[windy-fill thunderstorms-fill heavy-showers-fill flood-fill temp-cold-fill sun-fill avalanches-fill snowy-fill].freeze
 
-    MARKUPS = %i[p h1 h2 h3 h4 h5 h6].freeze
+    DESCRIPTION_TAGS = %i[p h1 h2 h3 h4 h5 h6].freeze
 
     # @param title [String] Titre du bandeau
     # @param description [String] Description du bandeau pour apporter du contexte (optionnel)
-    # @param type [String] Type de bandeau (info, waring, alert, weather-orange, weather-red, weather-purple, kidnapping, cyberattack, attack, witness), par défaut "info"
-    # @param markup [Symbol] Balise HTML à utiliser pour la description (p, h1, h2, h3, h4, h5, h6)
-    # @param icon [Boolean] Afficher ou non une icône, uniquement pour les bandeaux génériques, par défaut true
+    # @param type [String] Type de bandeau (info, waring, alert, weather-orange, weather-red, weather-purple, kidnapping, cyberattack, attack, witness)
+    # @param description_tag [Symbol] Balise HTML à utiliser pour la description (p, h1, h2, h3, h4, h5, h6)
+    # @param icon [Boolean] Afficher ou non une icône, uniquement pour les bandeaux génériques
     # @param icon_name [String] Nom de l'icône à afficher
-    # @param notice [Boolean] Ajout l’attribut role="notice" (si insertion du bandeau à la volée), par défaut false
-    # @param dismissible [Boolean] Ajouter un bouton de fermeture, par défaut false
-    # @param dismiss_label [String] Libellé du bouton de fermeture (optionnel, par défaut « Masquer le message »)
+    # @param notice [Boolean] Ajout l’attribut role="notice" (si insertion du bandeau à la volée)
+    # @param dismissible [Boolean] Ajouter un bouton de fermeture
+    # @param dismiss_label [String] Libellé du bouton de fermeture (optionnel)
     # @param link_label [String] Libellé du lien (optionnel)
     # @param link_href [String] URL du lien (optionnel)
     # @param link_title [String] Titre du lien (optionnel)
-    # @param link_blank [Boolean] Ouvrir le lien dans un nouvel onglet, par défaut true
-    def initialize(title:, description:, type: "info", markup: :p, icon: true, icon_name: nil, notice: false, dismissible: false, dismiss_label: "Masquer le message", link_label: nil, link_href: nil, link_title: nil, link_blank: true,
+    # @param link_blank [Boolean] Ouvrir le lien dans un nouvel onglet
+    def initialize(title:, description:, type: "info", description_tag: :p, icon: true, icon_name: nil, notice: false, dismissible: false, dismiss_label: "Masquer le message", link_label: nil, link_href: nil, link_title: nil, link_blank: true,
                    classes: [], html_attributes: {})
       @title = title
       @description = description
       @type = type
-      @markup = markup
+      @description_tag = description_tag
       @icon_name = icon_name
       @notice = notice
       @dismissible = dismissible
@@ -37,37 +37,35 @@ module DsfrComponent
       @link_title = link_title
       @link_blank = link_blank
 
+      # D’après les règles du DSFR les types non génériques ont forcément une icône
       @icon = if GENERIC_TYPES.include?(type)
                 icon
               else
                 true
               end
 
+      raise ArgumentError, "Invalid type: #{type}. Valid types: #{TYPES.join(', ')}" unless type_valid?
+
+      raise ArgumentError, "Invalid description tag: #{description_tag}" unless DESCRIPTION_TAGS.include?(description_tag)
+
+      if icon_name
+        raise ArgumentError, "L’icône n’est pas personnalisable sur les bandeaux d’alertes" if ALERT_TYPES.include?(type)
+        raise ArgumentError, "L’icône d’un bandeau de type météo doit être une icône météo (#{WEATHER_ICONS.join(', ')})" if WEATHER_TYPES.include?(type) && WEATHER_ICONS.exclude?(icon_name)
+      end
+
       super(classes: classes, html_attributes: html_attributes)
     end
 
   private
 
-    attr_reader :type, :title, :description, :markup, :icon, :icon_name, :notice, :dismissible, :link_label, :link_href, :link_title, :link_blank
+    attr_reader :type, :title, :description, :description_tag, :icon, :icon_name, :notice, :dismissible, :link_label, :link_href, :link_title, :link_blank
 
-    def type_class
-      raise ArgumentError, "Invalid type: #{type}. Valid types: #{TYPES.join(', ')}" unless type_valid?
-
+    def notice_class
       "fr-notice--#{type}"
     end
 
     def type_valid?
       TYPES.include?(type)
-    end
-
-    def markup_tag
-      raise ArgumentError, "Invalid markup: #{markup}" unless markup_valid?
-
-      markup
-    end
-
-    def markup_valid?
-      MARKUPS.include?(markup)
     end
 
     def link_display?
@@ -85,14 +83,11 @@ module DsfrComponent
     def icon_class
       return unless icon_name
 
-      raise ArgumentError, "L’icône n’est pas personnalisable sur les bandeaux d’alertes" if ALERT_TYPES.include?(type)
-      raise ArgumentError, "L’icône d’un bandeau de type météo doit être une icône météo (#{WEATHER_ICONS.join(', ')})" if WEATHER_TYPES.include?(type) && !WEATHER_ICONS.include?(icon_name)
-
       "fr-icon-#{icon_name}"
     end
 
     def default_attributes
-      class_attr = "fr-notice #{type_class}"
+      class_attr = "fr-notice #{notice_class}"
       class_attr += " fr-notice--no-icon" unless icon
 
       attr = { class: class_attr }

--- a/app/components/dsfr_component/notice_component.rb
+++ b/app/components/dsfr_component/notice_component.rb
@@ -1,0 +1,74 @@
+module DsfrComponent
+  class NoticeComponent < DsfrComponent::Base
+    TYPES = %i[info waring alert weather-orange weather-purple kidnapping cyberattack vigipirate witness].freeze
+    MARKUPS = %i[p h1 h2 h3 h4 h5 h6].freeze
+
+    # @param title [String] Titre du bandeau
+    # @param description [String] Description du bandeau pour apporter du contexte (optionnel)
+    # @param type [Symbol] Type de bandeau (info, waring, alert, weather-orange, weather-purple, kidnapping, cyberattack, vigipirate, witness), par défaut :info
+    # @param markup [Symbol] Balise HTML à utiliser pour la description (p, h1, h2, h3, h4, h5, h6)
+    # @param icon [Boolean] Afficher ou non une icône
+    # @param icon_name [String] Nom de l'icône à afficher
+    # @param notice [Boolean] Ajout l’attribut role="notice" (si insertion du bandeau à la volée), par défaut false
+    # @param dismissible [Boolean] Ajouter un bouton de fermeture, par défaut false
+    # @param link_label [String] Libellé du lien (optionnel)
+    # @param link_href [String] URL du lien (optionnel)
+    # @param link_title [String] Titre du lien (optionnel)
+    # @param link_blank [Boolean] Ouvrir le lien dans un nouvel onglet, par défaut true
+    def initialize(title:, description:, type: :info, markup: :p, icon: true, icon_name: nil, notice: false, dismissible: false, link_label: nil, link_href: nil, link_title: nil, link_blank: true,
+                   classes: [], html_attributes: {})
+      @title = title
+      @description = description
+      @type = type
+      @markup = markup
+      @icon = icon
+      @icon_name = icon_name
+      @notice = notice
+      @dismissible = dismissible
+      @link_label = link_label
+      @link_href = link_href
+      @link_title = link_title
+      @link_blank = link_blank
+
+      super(classes: classes, html_attributes: html_attributes)
+    end
+
+  private
+
+    attr_reader :type, :title, :description, :markup, :icon, :icon_name, :notice, :dismissible, :link_label, :link_href, :link_title, :link_blank
+
+    def type_class
+      raise ArgumentError, "Invalid type: #{type}" unless type_valid?
+
+      "fr-notice--#{type}"
+    end
+
+    def type_valid?
+      TYPES.include?(type)
+    end
+
+    def markup_tag
+      raise ArgumentError, "Invalid markup: #{markup}" unless markup_valid?
+
+      markup
+    end
+
+    def markup_valid?
+      MARKUPS.include?(markup)
+    end
+
+    def link_display?
+      link_label.present? && link_href.present?
+    end
+
+    def link_tag
+      return unless link_display?
+
+      link_to(link_label, link_href, title: link_title, target: link_blank ? "_blank" : "_self")
+    end
+
+    def default_attributes
+      { class: "fr-notice #{type_class}" }
+    end
+  end
+end

--- a/app/components/dsfr_component/notice_component.rb
+++ b/app/components/dsfr_component/notice_component.rb
@@ -1,34 +1,47 @@
 module DsfrComponent
   class NoticeComponent < DsfrComponent::Base
-    TYPES = %i[info waring alert weather-orange weather-purple kidnapping cyberattack vigipirate witness].freeze
+    GENERIC_TYPES = %w[info waring alert].freeze
+    WEATHER_TYPES = %w[weather-orange weather-red weather-purple].freeze
+    ALERT_TYPES = %w[kidnapping cyberattack attack witness].freeze
+    TYPES = GENERIC_TYPES + WEATHER_TYPES + ALERT_TYPES
+
+    WEATHER_ICONS = %w[windy-fill thunderstorms-fill heavy-showers-fill flood-fill temp-cold-fill sun-fill avalanches-fill snowy-fill].freeze
+
     MARKUPS = %i[p h1 h2 h3 h4 h5 h6].freeze
 
     # @param title [String] Titre du bandeau
     # @param description [String] Description du bandeau pour apporter du contexte (optionnel)
-    # @param type [Symbol] Type de bandeau (info, waring, alert, weather-orange, weather-purple, kidnapping, cyberattack, vigipirate, witness), par défaut :info
+    # @param type [String] Type de bandeau (info, waring, alert, weather-orange, weather-red, weather-purple, kidnapping, cyberattack, attack, witness), par défaut "info"
     # @param markup [Symbol] Balise HTML à utiliser pour la description (p, h1, h2, h3, h4, h5, h6)
-    # @param icon [Boolean] Afficher ou non une icône
+    # @param icon [Boolean] Afficher ou non une icône, uniquement pour les bandeaux génériques, par défaut true
     # @param icon_name [String] Nom de l'icône à afficher
     # @param notice [Boolean] Ajout l’attribut role="notice" (si insertion du bandeau à la volée), par défaut false
     # @param dismissible [Boolean] Ajouter un bouton de fermeture, par défaut false
+    # @param dismiss_label [String] Libellé du bouton de fermeture (optionnel, par défaut « Masquer le message »)
     # @param link_label [String] Libellé du lien (optionnel)
     # @param link_href [String] URL du lien (optionnel)
     # @param link_title [String] Titre du lien (optionnel)
     # @param link_blank [Boolean] Ouvrir le lien dans un nouvel onglet, par défaut true
-    def initialize(title:, description:, type: :info, markup: :p, icon: true, icon_name: nil, notice: false, dismissible: false, link_label: nil, link_href: nil, link_title: nil, link_blank: true,
+    def initialize(title:, description:, type: "info", markup: :p, icon: true, icon_name: nil, notice: false, dismissible: false, dismiss_label: "Masquer le message", link_label: nil, link_href: nil, link_title: nil, link_blank: true,
                    classes: [], html_attributes: {})
       @title = title
       @description = description
       @type = type
       @markup = markup
-      @icon = icon
       @icon_name = icon_name
       @notice = notice
       @dismissible = dismissible
+      @dismiss_label = dismiss_label
       @link_label = link_label
       @link_href = link_href
       @link_title = link_title
       @link_blank = link_blank
+
+      @icon = if GENERIC_TYPES.include?(type)
+                icon
+              else
+                true
+              end
 
       super(classes: classes, html_attributes: html_attributes)
     end
@@ -38,7 +51,7 @@ module DsfrComponent
     attr_reader :type, :title, :description, :markup, :icon, :icon_name, :notice, :dismissible, :link_label, :link_href, :link_title, :link_blank
 
     def type_class
-      raise ArgumentError, "Invalid type: #{type}" unless type_valid?
+      raise ArgumentError, "Invalid type: #{type}. Valid types: #{TYPES.join(', ')}" unless type_valid?
 
       "fr-notice--#{type}"
     end
@@ -64,11 +77,28 @@ module DsfrComponent
     def link_tag
       return unless link_display?
 
-      link_to(link_label, link_href, title: link_title, target: link_blank ? "_blank" : "_self")
+      target = @link_blank ? "_blank" : "_self"
+
+      link_to(link_label, link_href, title: link_title, target: target)
+    end
+
+    def icon_class
+      return unless icon_name
+
+      raise ArgumentError, "L’icône n’est pas personnalisable sur les bandeaux d’alertes" if ALERT_TYPES.include?(type)
+      raise ArgumentError, "L’icône d’un bandeau de type météo doit être une icône météo (#{WEATHER_ICONS.join(', ')})" if WEATHER_TYPES.include?(type) && !WEATHER_ICONS.include?(icon_name)
+
+      "fr-icon-#{icon_name}"
     end
 
     def default_attributes
-      { class: "fr-notice #{type_class}" }
+      class_attr = "fr-notice #{type_class}"
+      class_attr += " fr-notice--no-icon" unless icon
+
+      attr = { class: class_attr }
+      attr[:role] = "notice" if notice
+
+      attr
     end
   end
 end

--- a/app/components/dsfr_component/notice_component.rb
+++ b/app/components/dsfr_component/notice_component.rb
@@ -13,23 +13,23 @@ module DsfrComponent
     # @param description [String] Description du bandeau pour apporter du contexte (optionnel)
     # @param type [String] Type de bandeau (info, waring, alert, weather-orange, weather-red, weather-purple, kidnapping, cyberattack, attack, witness)
     # @param description_tag [Symbol] Balise HTML à utiliser pour la description (p, h1, h2, h3, h4, h5, h6)
-    # @param icon [Boolean] Afficher ou non une icône, uniquement pour les bandeaux génériques
+    # @param use_icon [Boolean] Afficher ou non une icône, uniquement pour les bandeaux génériques
     # @param icon_name [String] Nom de l'icône à afficher
-    # @param notice [Boolean] Ajout l’attribut role="notice" (si insertion du bandeau à la volée)
+    # @param use_notice [Boolean] Ajout l’attribut role="notice" (si insertion du bandeau à la volée)
     # @param dismissible [Boolean] Ajouter un bouton de fermeture
     # @param dismiss_label [String] Libellé du bouton de fermeture (optionnel)
     # @param link_label [String] Libellé du lien (optionnel)
     # @param link_href [String] URL du lien (optionnel)
     # @param link_title [String] Titre du lien (optionnel)
-    # @param link_blank [Boolean] Ouvrir le lien dans un nouvel onglet
-    def initialize(title:, description:, type: "info", description_tag: :p, icon: true, icon_name: nil, notice: false, dismissible: false, dismiss_label: "Masquer le message", link_label: nil, link_href: nil, link_title: nil, link_blank: true,
+    # @param link_blank [Boolean] Ouvrir le lien dans un nouvel onglet (optionnel)
+    def initialize(title:, description:, type: "info", description_tag: :p, use_icon: true, icon_name: nil, use_notice: false, dismissible: false, dismiss_label: "Masquer le message", link_label: nil, link_href: nil, link_title: nil, link_blank: true,
                    classes: [], html_attributes: {})
       @title = title
       @description = description
       @type = type
       @description_tag = description_tag
       @icon_name = icon_name
-      @notice = notice
+      @use_notice = use_notice
       @dismissible = dismissible
       @dismiss_label = dismiss_label
       @link_label = link_label
@@ -38,8 +38,8 @@ module DsfrComponent
       @link_blank = link_blank
 
       # D’après les règles du DSFR les types non génériques ont forcément une icône
-      @icon = if GENERIC_TYPES.include?(type)
-                icon
+      @use_icon = if GENERIC_TYPES.include?(type)
+                use_icon
               else
                 true
               end
@@ -58,7 +58,7 @@ module DsfrComponent
 
   private
 
-    attr_reader :type, :title, :description, :description_tag, :icon, :icon_name, :notice, :dismissible, :link_label, :link_href, :link_title, :link_blank
+    attr_reader :type, :title, :description, :description_tag, :use_icon, :icon_name, :use_notice, :dismissible, :link_label, :link_href, :link_title, :link_blank
 
     def notice_class
       "fr-notice--#{type}"
@@ -88,10 +88,10 @@ module DsfrComponent
 
     def default_attributes
       class_attr = "fr-notice #{notice_class}"
-      class_attr += " fr-notice--no-icon" unless icon
+      class_attr += " fr-notice--no-icon" unless use_icon
 
       attr = { class: class_attr }
-      attr[:role] = "notice" if notice
+      attr[:role] = "notice" if use_notice
 
       attr
     end

--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -19,6 +19,7 @@ module DsfrComponentsHelper
     dsfr_highlight: 'DsfrComponent::HighlightComponent',
     dsfr_skiplink: 'DsfrComponent::SkiplinkComponent',
     dsfr_callout: 'DsfrComponent::CalloutComponent',
+    dsfr_notice: 'DsfrComponent::NoticeComponent',
     # DO NOT REMOVE: new component mapping here
   }.freeze
   HELPER_NAME_TO_CLASS_NAME.each do |name, klass|

--- a/guide/content/components/notice.haml
+++ b/guide/content/components/notice.haml
@@ -1,0 +1,24 @@
+---
+title: Bandeau d'information importante - Notice
+---
+
+.fr-text-wrap
+  :markdown
+    Le bandeau d’information importante permet aux utilisateurs de voir ou d’accéder à une information importante et temporaire.
+
+= render('/partials/example.haml', caption: "Bandeau d'information importante", code: notice_default) do
+  :markdown
+    Ce bandeau répond à la plupart des cas d’usages.
+
+= render('/partials/example.haml', caption: "Bandeau d'information importante avec un bouton pour masquer", code: notice_dismissible) do
+  :markdown
+    Il est possible d’ajouter un bouton pour proposer à l’utilisateur de masquer le bandeau.
+
+= render('/partials/example.haml', caption: "Bandeau d'information importante avec un lien externe", code: notice_with_external_link) do
+  :markdown
+    Il est possible d’ajouter un lien pour rediriger l’utilisateur vers une page lui apportant des informations complémentaires.
+
+= render('/partials/example.haml', caption: "Bandeau d'information importante avec un lien interne", code: notice_with_internal_link)
+
+
+= render('/partials/related-info.haml', links: dsfr_component_doc_links("bandeau-d-information-importante", "notice"))

--- a/guide/content/components/notice.haml
+++ b/guide/content/components/notice.haml
@@ -16,7 +16,7 @@ title: Bandeau d'information importante - Notice
 
      - Les bandeaux génériques : #{DsfrComponent::NoticeComponent::GENERIC_TYPES.join(', ')}.
      - Les bandeaux d’alertes : #{DsfrComponent::NoticeComponent::ALERT_TYPES.join(', ')}.
-     - Les banedeaux d’information météorologique : #{DsfrComponent::NoticeComponent::WEATHER_TYPES.join(', ')}.
+     - Les bandeaux d’information météorologique : #{DsfrComponent::NoticeComponent::WEATHER_TYPES.join(', ')}.
 
 = render('/partials/example.haml', caption: "Bandeau d'information importante avec un bouton pour masquer", code: notice_dismissible) do
   :markdown

--- a/guide/content/components/notice.haml
+++ b/guide/content/components/notice.haml
@@ -14,9 +14,9 @@ title: Bandeau d'information importante - Notice
   :markdown
     Il est possible de changer le type de bandeau. Il existe 3 catégories de bandeaux :
 
-     - Les bandeaux génériques : #{DsfrComponent::NoticeComponent::GENERIC_TYPES.join(", ")}.
-     - Les bandeaux d’alertes : #{DsfrComponent::NoticeComponent::ALERT_TYPES.join(", ")}.
-     - Les banedeaux d’information météorologique : #{DsfrComponent::NoticeComponent::WEATHER_TYPES.join(", ")}.
+     - Les bandeaux génériques : #{DsfrComponent::NoticeComponent::GENERIC_TYPES.join(', ')}.
+     - Les bandeaux d’alertes : #{DsfrComponent::NoticeComponent::ALERT_TYPES.join(', ')}.
+     - Les banedeaux d’information météorologique : #{DsfrComponent::NoticeComponent::WEATHER_TYPES.join(', ')}.
 
 = render('/partials/example.haml', caption: "Bandeau d'information importante avec un bouton pour masquer", code: notice_dismissible) do
   :markdown
@@ -38,7 +38,7 @@ title: Bandeau d'information importante - Notice
     Il est possible de personnaliser l’icône du bandeau uniquement pour les bandeaux génériques.
 
     Pour les bandeaux d’information météorologique, l’icône doit être sélectionnée parmi les icônes météorologiques suivantes :
-    #{DsfrComponent::NoticeComponent::WEATHER_ICONS.join(", ")}.
+    #{DsfrComponent::NoticeComponent::WEATHER_ICONS.join(', ')}.
 
     Les icônes d’alertes ne sont pas personnalisables.
 

--- a/guide/content/components/notice.haml
+++ b/guide/content/components/notice.haml
@@ -10,15 +10,37 @@ title: Bandeau d'information importante - Notice
   :markdown
     Ce bandeau répond à la plupart des cas d’usages.
 
+= render('/partials/example.haml', caption: "Bandeau d’un autre type", code: notice_alert) do
+  :markdown
+    Il est possible de changer le type de bandeau. Il existe 3 catégories de bandeaux :
+
+     - Les bandeaux génériques : #{DsfrComponent::NoticeComponent::GENERIC_TYPES.join(", ")}.
+     - Les bandeaux d’alertes : #{DsfrComponent::NoticeComponent::ALERT_TYPES.join(", ")}.
+     - Les banedeaux d’information météorologique : #{DsfrComponent::NoticeComponent::WEATHER_TYPES.join(", ")}.
+
 = render('/partials/example.haml', caption: "Bandeau d'information importante avec un bouton pour masquer", code: notice_dismissible) do
   :markdown
     Il est possible d’ajouter un bouton pour proposer à l’utilisateur de masquer le bandeau.
+    L’attribut `dismiss_label` est facultatif, par défaut « Masquer le message ».
 
 = render('/partials/example.haml', caption: "Bandeau d'information importante avec un lien externe", code: notice_with_external_link) do
   :markdown
     Il est possible d’ajouter un lien pour rediriger l’utilisateur vers une page lui apportant des informations complémentaires.
 
 = render('/partials/example.haml', caption: "Bandeau d'information importante avec un lien interne", code: notice_with_internal_link)
+
+= render('/partials/example.haml', caption: "Bandeau d'information importante sans icône", code: notice_without_icon) do
+  :markdown
+    Il est possible de masquer l’icône du bandeau (uniquement pour les bandeaux génériques).
+
+= render('/partials/example.haml', caption: "Bandeau d'information importante avec une icône personnalisée", code: notice_with_icon_name) do
+  :markdown
+    Il est possible de personnaliser l’icône du bandeau uniquement pour les bandeaux génériques.
+
+    Pour les bandeaux d’information météorologique, l’icône doit être sélectionnée parmi les icônes météorologiques suivantes :
+    #{DsfrComponent::NoticeComponent::WEATHER_ICONS.join(", ")}.
+
+    Les icônes d’alertes ne sont pas personnalisables.
 
 
 = render('/partials/related-info.haml', links: dsfr_component_doc_links("bandeau-d-information-importante", "notice"))

--- a/guide/lib/examples/notice_helpers.rb
+++ b/guide/lib/examples/notice_helpers.rb
@@ -43,5 +43,3 @@ module Examples
     end
   end
 end
-
-

--- a/guide/lib/examples/notice_helpers.rb
+++ b/guide/lib/examples/notice_helpers.rb
@@ -32,7 +32,7 @@ module Examples
 
     def notice_without_icon
       <<~RAW
-        = dsfr_notice(title: "Information", description: "Ceci est une info importante", icon: false)
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante", use_icon: false)
       RAW
     end
 

--- a/guide/lib/examples/notice_helpers.rb
+++ b/guide/lib/examples/notice_helpers.rb
@@ -1,0 +1,29 @@
+module Examples
+  module NoticeHelpers
+    def notice_default
+      <<~RAW
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante")
+      RAW
+    end
+
+    def notice_dismissible
+      <<~RAW
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante que vous pouvez masquer", dismissible: true)
+      RAW
+    end
+
+    def notice_with_external_link
+      <<~RAW
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante avec un super lien", link_label: "En savoir plus", link_href: "https://example.com", link_title: "En savoir plus - Nouvel onglet")
+      RAW
+    end
+
+    def notice_with_internal_link
+      <<~RAW
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante avec un super lien", link_label: "En savoir plus", link_href: "#", link_blank: false)
+      RAW
+    end
+  end
+end
+
+

--- a/guide/lib/examples/notice_helpers.rb
+++ b/guide/lib/examples/notice_helpers.rb
@@ -6,9 +6,15 @@ module Examples
       RAW
     end
 
+    def notice_alert
+      <<~RAW
+        = dsfr_notice(title: "Alerte", description: "Ceci est une alerte importante", type: "alert")
+      RAW
+    end
+
     def notice_dismissible
       <<~RAW
-        = dsfr_notice(title: "Information", description: "Ceci est une info importante que vous pouvez masquer", dismissible: true)
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante que vous pouvez masquer", dismissible: true, dismiss_label: "Masquer")
       RAW
     end
 
@@ -21,6 +27,18 @@ module Examples
     def notice_with_internal_link
       <<~RAW
         = dsfr_notice(title: "Information", description: "Ceci est une info importante avec un super lien", link_label: "En savoir plus", link_href: "#", link_blank: false)
+      RAW
+    end
+
+    def notice_without_icon
+      <<~RAW
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante", icon: false)
+      RAW
+    end
+
+    def notice_with_icon_name
+      <<~RAW
+        = dsfr_notice(title: "Information", description: "Ceci est une info importante", icon_name: "alarm-warning-fill")
       RAW
     end
   end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -52,3 +52,4 @@ use_helper Examples::TabsHelpers
 use_helper Examples::HighlightHelpers
 use_helper Examples::SkiplinkHelpers
 use_helper Examples::CalloutHelpers
+use_helper Examples::NoticeHelpers

--- a/spec/components/dsfr_component/notice_component_spec.rb
+++ b/spec/components/dsfr_component/notice_component_spec.rb
@@ -1,5 +1,190 @@
 require 'spec_helper'
 
 RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
-  pending "Add some examples to cover NoticeComponent"
+  subject { render_inline(described_class.new(**args)) }
+
+  let(:args) { { title: "Information", description: "Ceci est un message d'information" } }
+
+  it "renders correctly" do
+    subject
+
+    expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
+      with_tag(:div, with: { class: "fr-container" }) do
+        with_tag(:div, with: { class: "fr-notice__body" }) do
+          with_tag(:p) do
+            with_tag(:span, with: { class: "fr-notice__title" }, text: "Information")
+            with_tag(:span, with: { class: "fr-notice__desc" }, text: "Ceci est un message d'information")
+          end
+          without_tag(:button, with: { class: "fr-btn--close fr-btn", type: "button", title: "Fermer" })
+        end
+      end
+    end
+  end
+
+  context "when type is alert" do
+    let(:args) { { title: "Alerte", description: "Ceci est un message d'alerte", type: "alert" } }
+
+    it "renders correctly" do
+      subject
+
+      expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--alert" }) do
+        with_tag(:div, with: { class: "fr-container" }) do
+          with_tag(:div, with: { class: "fr-notice__body" }) do
+            with_tag(:p) do
+              with_tag(:span, with: { class: "fr-notice__title" }, text: "Alerte")
+              with_tag(:span, with: { class: "fr-notice__desc" }, text: "Ceci est un message d'alerte")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  context "when dismissible" do
+    let(:args) { { title: "Information", description: "Ceci est un message d'information", dismissible: true, dismiss_label: "Fermer" } }
+
+    it "renders correctly" do
+      subject
+
+      expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
+        with_tag(:div, with: { class: "fr-container" }) do
+          with_tag(:div, with: { class: "fr-notice__body" }) do
+            with_tag(:button, with: { class: "fr-btn--close fr-btn", type: "button", title: "Fermer" }, text: "Fermer")
+          end
+        end
+      end
+    end
+  end
+
+  context "when link is present" do
+    let(:args) { { title: "Information", description: "Ceci est un message d'information", link_label: "En savoir plus", link_href: "https://example.com", link_title: "En savoir plus - Nouvel onglet" } }
+
+    it "renders correctly" do
+      subject
+
+      expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
+        with_tag(:div, with: { class: "fr-container" }) do
+          with_tag(:div, with: { class: "fr-notice__body" }) do
+            with_tag(:p) do
+              with_tag(:a, with: { href: "https://example.com", title: "En savoir plus - Nouvel onglet", target: "_blank" }, text: "En savoir plus")
+            end
+          end
+        end
+      end
+    end
+
+    context "when link_blank is false" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", link_label: "En savoir plus", link_href: "#", link_title: "En savoir plus", link_blank: false } }
+
+      it "renders correctly" do
+        subject
+
+        expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
+          with_tag(:div, with: { class: "fr-container" }) do
+            with_tag(:div, with: { class: "fr-notice__body" }) do
+              with_tag(:p) do
+                with_tag(:a, with: { href: "#", title: "En savoir plus", target: "_self" }, text: "En savoir plus")
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when icon is false" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", icon: false } }
+
+      it "renders correctly" do
+        subject
+
+        expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info fr-notice--no-icon" })
+      end
+    end
+
+    context "when icon is false and notice has weather type" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "weather-red", icon: false } }
+
+      it "renders correctly" do
+        subject
+
+        expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--weather-red" })
+      end
+    end
+
+    context "when icon is false and notice has alert type" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "attack", icon: false } }
+
+      it "renders correctly" do
+        subject
+
+        expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--attack" })
+      end
+    end
+
+    context "when icon_name is present" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", icon_name: "alarm-warning-fill" } }
+
+      it "renders correctly" do
+        subject
+
+        expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
+          with_tag(:div, with: { class: "fr-container" }) do
+            with_tag(:div, with: { class: "fr-notice__body" }) do
+              with_tag(:p) do
+                with_tag(:span, with: { class: "fr-notice__title fr-icon-alarm-warning-fill" }, text: "Information")
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when notice has weather type and icon_name is invalid" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "weather-red", icon_name: "alarm-warning-fill" } }
+
+      it "raise" do
+        expect do
+          subject
+        end.to raise_error(ArgumentError, "L’icône d’un bandeau de type météo doit être une icône météo (windy-fill, thunderstorms-fill, heavy-showers-fill, flood-fill, temp-cold-fill, sun-fill, avalanches-fill, snowy-fill)")
+      end
+    end
+
+    context "when notice has weather type and icon_name is valid" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "weather-red", icon_name: "windy-fill" } }
+
+      it "renders correctly" do
+        subject
+
+        expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--weather-red" }) do
+          with_tag(:div, with: { class: "fr-container" }) do
+            with_tag(:div, with: { class: "fr-notice__body" }) do
+              with_tag(:p) do
+                with_tag(:span, with: { class: "fr-notice__title fr-icon-windy-fill" }, text: "Information")
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "when notice has alert type and icon_name is present" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "attack", icon_name: "alarm-warning-fill" } }
+
+      it "raise" do
+        expect do
+          subject
+        end.to raise_error(ArgumentError, "L’icône n’est pas personnalisable sur les bandeaux d’alertes")
+      end
+    end
+
+    context "when notice has notice role" do
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", notice: true } }
+
+      it "renders correctly" do
+        subject
+
+        expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info", role: "notice" })
+      end
+    end
+  end
 end

--- a/spec/components/dsfr_component/notice_component_spec.rb
+++ b/spec/components/dsfr_component/notice_component_spec.rb
@@ -1,12 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
-  subject { render_inline(described_class.new(**args)) }
-
   let(:args) { { title: "Information", description: "Ceci est un message d'information" } }
 
   it "renders correctly" do
-    subject
+    render_inline(described_class.new(**args))
 
     expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
       with_tag(:div, with: { class: "fr-container" }) do
@@ -25,7 +23,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
     let(:args) { { title: "Alerte", description: "Ceci est un message d'alerte", type: "alert" } }
 
     it "renders correctly" do
-      subject
+      render_inline(described_class.new(**args))
 
       expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--alert" }) do
         with_tag(:div, with: { class: "fr-container" }) do
@@ -44,7 +42,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
     let(:args) { { title: "Information", description: "Ceci est un message d'information", dismissible: true, dismiss_label: "Fermer" } }
 
     it "renders correctly" do
-      subject
+      render_inline(described_class.new(**args))
 
       expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
         with_tag(:div, with: { class: "fr-container" }) do
@@ -60,7 +58,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
     let(:args) { { title: "Information", description: "Ceci est un message d'information", link_label: "En savoir plus", link_href: "https://example.com", link_title: "En savoir plus - Nouvel onglet" } }
 
     it "renders correctly" do
-      subject
+      render_inline(described_class.new(**args))
 
       expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
         with_tag(:div, with: { class: "fr-container" }) do
@@ -77,7 +75,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       let(:args) { { title: "Information", description: "Ceci est un message d'information", link_label: "En savoir plus", link_href: "#", link_title: "En savoir plus", link_blank: false } }
 
       it "renders correctly" do
-        subject
+        render_inline(described_class.new(**args))
 
         expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
           with_tag(:div, with: { class: "fr-container" }) do
@@ -95,7 +93,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       let(:args) { { title: "Information", description: "Ceci est un message d'information", icon: false } }
 
       it "renders correctly" do
-        subject
+        render_inline(described_class.new(**args))
 
         expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info fr-notice--no-icon" })
       end
@@ -105,7 +103,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "weather-red", icon: false } }
 
       it "renders correctly" do
-        subject
+        render_inline(described_class.new(**args))
 
         expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--weather-red" })
       end
@@ -115,7 +113,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "attack", icon: false } }
 
       it "renders correctly" do
-        subject
+        render_inline(described_class.new(**args))
 
         expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--attack" })
       end
@@ -125,7 +123,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       let(:args) { { title: "Information", description: "Ceci est un message d'information", icon_name: "alarm-warning-fill" } }
 
       it "renders correctly" do
-        subject
+        render_inline(described_class.new(**args))
 
         expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
           with_tag(:div, with: { class: "fr-container" }) do
@@ -144,8 +142,11 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
 
       it "raise" do
         expect do
-          subject
-        end.to raise_error(ArgumentError, "L’icône d’un bandeau de type météo doit être une icône météo (windy-fill, thunderstorms-fill, heavy-showers-fill, flood-fill, temp-cold-fill, sun-fill, avalanches-fill, snowy-fill)")
+          render_inline(described_class.new(**args))
+        end.to raise_error(
+          ArgumentError,
+          "L’icône d’un bandeau de type météo doit être une icône météo (windy-fill, thunderstorms-fill, heavy-showers-fill, flood-fill, temp-cold-fill, sun-fill, avalanches-fill, snowy-fill)"
+        )
       end
     end
 
@@ -153,7 +154,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "weather-red", icon_name: "windy-fill" } }
 
       it "renders correctly" do
-        subject
+        render_inline(described_class.new(**args))
 
         expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--weather-red" }) do
           with_tag(:div, with: { class: "fr-container" }) do
@@ -172,7 +173,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
 
       it "raise" do
         expect do
-          subject
+          render_inline(described_class.new(**args))
         end.to raise_error(ArgumentError, "L’icône n’est pas personnalisable sur les bandeaux d’alertes")
       end
     end
@@ -181,7 +182,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       let(:args) { { title: "Information", description: "Ceci est un message d'information", notice: true } }
 
       it "renders correctly" do
-        subject
+        render_inline(described_class.new(**args))
 
         expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info", role: "notice" })
       end

--- a/spec/components/dsfr_component/notice_component_spec.rb
+++ b/spec/components/dsfr_component/notice_component_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
+  pending "Add some examples to cover NoticeComponent"
+end

--- a/spec/components/dsfr_component/notice_component_spec.rb
+++ b/spec/components/dsfr_component/notice_component_spec.rb
@@ -188,4 +188,30 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
       end
     end
   end
+
+  context "when description tag is set" do
+    let(:args) { { title: "Information", description: "Ceci est un message d'information", description_tag: :h1 } }
+
+    it "renders correctly" do
+      render_inline(described_class.new(**args))
+
+      expect(rendered_content).to have_tag(:div, with: { class: "fr-notice fr-notice--info" }) do
+        with_tag(:div, with: { class: "fr-container" }) do
+          with_tag(:div, with: { class: "fr-notice__body" }) do
+            with_tag(:h1)
+          end
+        end
+      end
+    end
+  end
+
+  context "when description tag is invalid" do
+    let(:args) { { title: "Information", description: "Ceci est un message d'information", description_tag: :div } }
+
+    it "raise" do
+      expect do
+        render_inline(described_class.new(**args))
+      end.to raise_error(ArgumentError, "Invalid description tag: div")
+    end
+  end
 end

--- a/spec/components/dsfr_component/notice_component_spec.rb
+++ b/spec/components/dsfr_component/notice_component_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
     end
 
     context "when icon is false" do
-      let(:args) { { title: "Information", description: "Ceci est un message d'information", icon: false } }
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", use_icon: false } }
 
       it "renders correctly" do
         render_inline(described_class.new(**args))
@@ -100,7 +100,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
     end
 
     context "when icon is false and notice has weather type" do
-      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "weather-red", icon: false } }
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "weather-red", use_icon: false } }
 
       it "renders correctly" do
         render_inline(described_class.new(**args))
@@ -110,7 +110,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
     end
 
     context "when icon is false and notice has alert type" do
-      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "attack", icon: false } }
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", type: "attack", use_icon: false } }
 
       it "renders correctly" do
         render_inline(described_class.new(**args))
@@ -179,7 +179,7 @@ RSpec.describe(DsfrComponent::NoticeComponent, type: :component) do
     end
 
     context "when notice has notice role" do
-      let(:args) { { title: "Information", description: "Ceci est un message d'information", notice: true } }
+      let(:args) { { title: "Information", description: "Ceci est un message d'information", use_notice: true } }
 
       it "renders correctly" do
         render_inline(described_class.new(**args))


### PR DESCRIPTION
Closes #60 

Reste à faire : 

- [x] Écriture des specs
- [x] Ajout d’exemples
- [x] Personnalisation de l’icône (uniquement pour les types de base)
- [x] Personnalisation du libellé de fermeture de bandeau