### PR TITLE
Fix: position du titre dans le stepper

### DIFF
--- a/app/components/dsfr_component/stepper_component.html.erb
+++ b/app/components/dsfr_component/stepper_component.html.erb
@@ -1,9 +1,9 @@
 <%= tag.div(**html_attributes) do %>
   <h2 class="fr-stepper__title">
+    <%= title %>
     <span class="fr-stepper__state">
       Étape <%= value %> sur <%= max %>
     </span>
-    <%= title %>
   </h2>
   <div
     class="fr-stepper__steps"


### PR DESCRIPTION
En consultant la doc et le storybook du DSFR on peut s’apercevoir que le titre du stepper s’affiche comme ceci :

<img width="449" alt="image" src="https://github.com/user-attachments/assets/bd452cdf-afe7-49ec-9d81-d14b0587dea0" />

Or, aujourd’hui, notre implémentation produit ceci : 

<img width="821" alt="image" src="https://github.com/user-attachments/assets/27b4aca6-0887-46ed-af86-0fe85361dbcf" />

On corrige donc l’ordre pour afficher le numéro des étapes et le titre dans le bon ordre.
