### PR TITLE
Icône personnalisé pour les alertes par défaut

### DIFF
--- a/app/components/dsfr_component/alert_component.rb
+++ b/app/components/dsfr_component/alert_component.rb
@@ -20,6 +20,7 @@ class DsfrComponent::AlertComponent < DsfrComponent::Base
   def call
     raise ArgumentError, "SM alerts cannot have titles but must have a content" if @size == :sm && (@title.present? || content.blank?)
     raise ArgumentError, "MD Alerts must have a title" if @size == :md && @title.blank?
+    raise ArgumentError, "icon_name should be set only on default alert" if @type && @icon_name
 
     tag.div(**html_attributes) do
       safe_join([title_tag, content_tag, close_button_tag])

--- a/app/components/dsfr_component/alert_component.rb
+++ b/app/components/dsfr_component/alert_component.rb
@@ -7,11 +7,12 @@ class DsfrComponent::AlertComponent < DsfrComponent::Base
   # @param size [Symbol] alert size : `:md` (default) or `:sm`
   # @param close_button [Boolean] display a close button to remove the alert
   # @note in size MD the title is required but the content is optional. In size SM there should be not title but the content is required
-  def initialize(type:, title: nil, size: :md, close_button: false, classes: [], html_attributes: {})
+  def initialize(type: nil, title: nil, size: :md, close_button: false, icon_name: nil, classes: [], html_attributes: {})
     @title = title
     @type = type
     @size = size
     @close_button = close_button
+    @icon_name = icon_name
 
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -27,10 +28,10 @@ class DsfrComponent::AlertComponent < DsfrComponent::Base
 
 private
 
-  attr_reader :title, :type, :size, :close_button
+  attr_reader :title, :type, :size, :close_button, :icon_name
 
   def default_attributes
-    { class: %w(fr-alert) + [type_class, size_class].compact }
+    { class: %w(fr-alert) + [icon_class, type_class, size_class].compact }
   end
 
   def title_tag
@@ -57,7 +58,14 @@ private
     end
   end
 
+  def icon_class
+    return nil if icon_name.blank?
+
+    "fr-icon-#{icon_name}"
+  end
+
   def type_class
+    return nil if type.blank?
     fail(ArgumentError, type_error_message) unless valid_type?
 
     "fr-alert--#{type}"

--- a/guide/content/components/alert.haml
+++ b/guide/content/components/alert.haml
@@ -14,7 +14,8 @@ title: Alerte - Alert
          caption: "Alerte MD de succès avec du contenu",
          code: alert_md_success_with_content) do
   :markdown
-    Une alerte a un `type` obligatoire parmi `:error`, `:success`, `:info` ou `:warning`.
+    Une alerte a un `type` facultatif parmi `:error`, `:success`, `:info` ou `:warning`.
+    Si le type n'est pas précisé, l'alerte par défaut a une couleur grise.
 
 = render('/partials/example.haml',
          caption: "Alerte MD de succès sans contenu",
@@ -33,5 +34,11 @@ title: Alerte - Alert
 = render('/partials/example.haml',
          caption: "Alerte avec un bouton pour fermer",
          code: alert_md_with_close_button)
+
+= render('/partials/example.haml',
+         caption: "Alerte avec une icône personnalisée",
+         code: alert_with_icon) do
+  :markdown
+    L'alerte peut avoir une icône personnalisée quand le type n’est pas défini.
 
 = render('/partials/related-info.haml', links: dsfr_component_doc_links("alerte", "alert"))

--- a/guide/lib/examples/alert_helpers.rb
+++ b/guide/lib/examples/alert_helpers.rb
@@ -2,8 +2,8 @@ module Examples
   module AlertHelpers
     def alert_md_success_with_content
       <<~ALERT
-        = dsfr_alert(type: :success, title: "Succès de votre inscription") do |alert|
-          | Votre inscription a bien été enregistrée
+        = dsfr_alert(type: :success, title: "Succès de votre inscription") do
+          Votre inscription a bien été enregistrée
       ALERT
     end
 
@@ -16,14 +16,21 @@ module Examples
     def alert_sm_error
       <<~ALERT
         = dsfr_alert(type: :error, size: :sm) do
-          | Une erreur est survenue pendant votre inscription, veuillez contacter votre administrateur
+          Une erreur est survenue pendant votre inscription, veuillez contacter votre administrateur
       ALERT
     end
 
     def alert_md_with_close_button
       <<~ALERT
         = dsfr_alert(type: :success, title: "Bienvenue", close_button: true) do
-          | Merci pour votre inscription
+          Merci pour votre inscription
+      ALERT
+    end
+
+    def alert_with_icon
+      <<~ALERT
+        = dsfr_alert(icon_name: "eye-fill", size: :sm) do
+          Votre inscription est en cours de traitement
       ALERT
     end
   end

--- a/spec/components/dsfr_component/alert_component_spec.rb
+++ b/spec/components/dsfr_component/alert_component_spec.rb
@@ -90,6 +90,26 @@ RSpec.describe(DsfrComponent::AlertComponent, type: :component) do
     end
   end
 
+  context "when set icon name on non default alert" do
+    it "raise ArgumentError" do
+      expect do
+        render_inline(described_class.new(type: :success, title: "Erreur numéro 123", size: :lg, icon_name: "eye-fill"))
+      end.to raise_error(ArgumentError, /invalid alert size/)
+    end
+  end
+
+  context "when icon name present" do
+    subject! do
+      render_inline(described_class.new(title: "Regarde ma super icône", icon_name: "eye-fill"))
+    end
+
+    it "renders both title and content" do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-alert fr-icon-eye-fill" }) do
+        with_tag("h3", text: "Regarde ma super icône")
+      end
+    end
+  end
+
   # it_behaves_like 'a component that accepts custom classes'
   # it_behaves_like 'a component that accepts custom HTML attributes'
 end


### PR DESCRIPTION
En explorant le storybook du DSFR je me suis rendu compte de 2 choses :

- Il est possible d’avoir une alerte « par défaut » de couleur grise
- Cette alerte par défaut permet d’avoir une icône personnalisée

On ajoute donc cette possibilité au composant dans cette PR.