### PR TITLE
fix: Add missing button type="button" to accordion section toggler

### DIFF
--- a/app/components/dsfr_component/accordion_component/section_component.html.erb
+++ b/app/components/dsfr_component/accordion_component/section_component.html.erb
@@ -1,6 +1,7 @@
 <%= tag.section(**html_attributes) do %>
   <%= tag.send(starting_header_tag, class: "fr-accordion__title") do %>
     <button
+        type="button"
         class="fr-accordion__btn"
         aria-expanded="<%= expanded? ? "true" : "false" %>"
         aria-controls="<%= id %>"

--- a/spec/components/dsfr_component/accordion_component_spec.rb
+++ b/spec/components/dsfr_component/accordion_component_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe(DsfrComponent::AccordionComponent, type: :component) do
       expect(rendered_content).to have_tag('div', with: { class: "fr-accordions-group" }) do
         with_tag('section', with: { class: 'fr-accordion' }) do
           with_tag("h3", with: { class: "fr-accordion__title" }) do
-            with_tag("button", with: { class: "fr-accordion__btn", "aria-expanded": "false" }, text: /Un/)
+            with_tag("button", with: { type: "button", class: "fr-accordion__btn", "aria-expanded": "false" }, text: /Un/)
           end
           with_tag("div", with: { class: "fr-collapse" }, text: /Premier contenu/)
         end
         with_tag('section', with: { class: 'fr-accordion' }) do
           with_tag("h3", with: { class: "fr-accordion__title" }) do
-            with_tag("button", with: { class: "fr-accordion__btn", "aria-expanded": "false" }, text: /Deux/)
+            with_tag("button", with: { type: "button", class: "fr-accordion__btn", "aria-expanded": "false" }, text: /Deux/)
           end
           with_tag("div", with: { class: "fr-collapse" }, text: /Deuxième contenu/)
         end


### PR DESCRIPTION
When an accordion is inside a form, clicking the button submits the form instead of toggling the section. 

See https://storybook.systeme-de-design.gouv.fr/?path=%2Fdocs%2Faccordion--docs