### PR TITLE
feat: Extract dropdown component

### DIFF
--- a/app/components/dsfr_component/dropdown_component.rb
+++ b/app/components/dsfr_component/dropdown_component.rb
@@ -6,7 +6,6 @@ module DsfrComponent
     def initialize(title:, collapse_html_attributes: {}, html_attributes: {})
       @title = title
       @collapse_html_attributes = collapse_html_attributes
-      @collapse_html_attributes[:id] ||= "dropdown-#{object_id}"
 
       super(html_attributes: html_attributes)
     end
@@ -30,7 +29,7 @@ module DsfrComponent
     end
 
     def dropdown_id
-      collapse_html_attributes[:id]
+      collapse_html_attributes[:id] ||= "dropdown-#{object_id}"
     end
   end
 end

--- a/app/components/dsfr_component/dropdown_component.rb
+++ b/app/components/dsfr_component/dropdown_component.rb
@@ -1,10 +1,8 @@
 module DsfrComponent
   class DropdownComponent < DsfrComponent::Base
-    # A dropdown component that displays content when a button is clicked.
-    #
-    # @param title [String] The title of the dropdown button
-    # @param collapse_html_attributes [Hash] Additional HTML attributes for the collapse div
-    # @param html_attributes [Hash] Additional HTML attributes for the button
+    # @param title [String] Intitulé du bouton d'ouverture
+    # @param collapse_html_attributes [Hash] Attributs HTML additionnels pour le bloc masqué (optionnels)
+    # @param html_attributes [Hash] Attributs HTML additionnels pour le bouton (optionnels)
     def initialize(title:, collapse_html_attributes: {}, html_attributes: {})
       @title = title
       @collapse_html_attributes = collapse_html_attributes

--- a/app/components/dsfr_component/dropdown_component.rb
+++ b/app/components/dsfr_component/dropdown_component.rb
@@ -6,6 +6,7 @@ module DsfrComponent
     def initialize(title:, collapse_html_attributes: {}, html_attributes: {})
       @title = title
       @collapse_html_attributes = collapse_html_attributes
+      @html_attributes = html_attributes # Requis pour pouvoir adapter default_attributes
 
       super(html_attributes: html_attributes)
     end
@@ -17,10 +18,11 @@ module DsfrComponent
         end
     end
 
-    attr_reader :title, :collapse_html_attributes
+    attr_reader :title, :collapse_html_attributes, :html_attributes
 
     def default_attributes
-      { class: "fr-btn", "aria-expanded": "false", "aria-controls": dropdown_id }
+      button_class = "fr-btn" unless html_attributes[:class].to_s.include?("fr-nav__btn")
+      { class: button_class, "aria-expanded": "false", "aria-controls": dropdown_id }
     end
 
     def collapse_attributes

--- a/app/components/dsfr_component/dropdown_component.rb
+++ b/app/components/dsfr_component/dropdown_component.rb
@@ -1,0 +1,38 @@
+module DsfrComponent
+  class DropdownComponent < DsfrComponent::Base
+    # A dropdown component that displays content when a button is clicked.
+    #
+    # @param title [String] The title of the dropdown button
+    # @param collapse_html_attributes [Hash] Additional HTML attributes for the collapse div
+    # @param html_attributes [Hash] Additional HTML attributes for the button
+    def initialize(title:, collapse_html_attributes: {}, html_attributes: {})
+      @title = title
+      @collapse_html_attributes = collapse_html_attributes
+      @collapse_html_attributes[:id] ||= "dropdown-#{object_id}"
+
+      super(html_attributes: html_attributes)
+    end
+
+    def call
+      tag.button(title, **html_attributes) +
+        tag.div(**collapse_attributes) do
+          content
+        end
+    end
+
+    attr_reader :title, :collapse_html_attributes
+
+    def default_attributes
+      { class: "fr-btn", "aria-expanded": "false", "aria-controls": dropdown_id }
+    end
+
+    def collapse_attributes
+      collapse_class = collapse_html_attributes.delete(:class)
+      { class: class_names("fr-collapse", collapse_class), id: dropdown_id }.merge(collapse_html_attributes)
+    end
+
+    def dropdown_id
+      collapse_html_attributes[:id]
+    end
+  end
+end

--- a/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
+++ b/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
@@ -9,12 +9,12 @@ class DsfrComponent::HeaderComponent::DirectLinkDropdownComponent < DsfrComponen
   end
 
   def call
-    render(DsfrComponent::DropdownComponent.new(
-             title: title,
-             html_attributes: button_attributes,
-             collapse_html_attributes: collapse_attributes
-           )) do
-      tag.ul(class: 'fr-menu__list') do
+    render DsfrComponent::DropdownComponent.new(
+      title: title,
+      html_attributes: button_attributes,
+      collapse_html_attributes: collapse_attributes
+    ) do
+      tag.ul(class: "fr-menu__list") do
         links.map do |link|
           tag.li link.call
         end.join.html_safe

--- a/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
+++ b/app/components/dsfr_component/header_component/direct_link_dropdown_component.rb
@@ -9,14 +9,17 @@ class DsfrComponent::HeaderComponent::DirectLinkDropdownComponent < DsfrComponen
   end
 
   def call
-    tag.button(title, **html_attributes) +
-      tag.div(class: 'fr-collapse fr-menu', id: menu_id) do
-        tag.ul(class: 'fr-menu__list') do
-          links.map do |link|
-            tag.li link.call
-          end.join.html_safe
-        end
+    render(DsfrComponent::DropdownComponent.new(
+             title: title,
+             html_attributes: button_attributes,
+             collapse_html_attributes: collapse_attributes
+           )) do
+      tag.ul(class: 'fr-menu__list') do
+        links.map do |link|
+          tag.li link.call
+        end.join.html_safe
       end
+    end
   end
 
 private
@@ -24,11 +27,14 @@ private
   attr_reader :title, :active
 
   def default_attributes
-    { class: 'fr-nav__btn', "aria-expanded": "false", "aria-controls": menu_id } \
-      .merge(active ? { "aria-current": 'true' } : {})
+    {}
   end
 
-  def menu_id
-    @menu_id ||= "menu-#{title.parameterize}"
+  def button_attributes
+    { class: 'fr-nav__btn' }.merge(active ? { "aria-current": 'true' } : {})
+  end
+
+  def collapse_attributes
+    { class: 'fr-menu', id: "menu-#{title.parameterize}" }
   end
 end

--- a/app/helpers/dsfr_components_helper.rb
+++ b/app/helpers/dsfr_components_helper.rb
@@ -22,6 +22,7 @@ module DsfrComponentsHelper
     dsfr_notice: 'DsfrComponent::NoticeComponent',
     dsfr_search: 'DsfrComponent::SearchComponent',
     dsfr_proconnect_button: 'DsfrComponent::ProconnectButtonComponent',
+    dsfr_dropdown: 'DsfrComponent::DropdownComponent',
     # DO NOT REMOVE: new component mapping here
   }.freeze
   HELPER_NAME_TO_CLASS_NAME.each do |name, klass|

--- a/guide/content/components/dropdown.haml
+++ b/guide/content/components/dropdown.haml
@@ -1,0 +1,25 @@
+---
+title: Menu déroulant - Dropdown
+---
+
+.fr-text-wrap
+  :markdown
+    Le composant de menu déroulant (dropdown) permet d'afficher du contenu qui apparaît et disparaît lorsque l'utilisateur clique sur un bouton.
+
+= render "/partials/example.haml", caption: "Menu déroulant simple", code: dropdown_simple do
+  :markdown
+    Un menu déroulant simple est composé d'un bouton et d'un contenu qui apparaît lorsque l'utilisateur clique sur le bouton.
+
+= render "/partials/example.haml", caption: "Menu déroulant avec une liste", code: dropdown_with_list do
+  :markdown
+    Un menu déroulant peut contenir une liste d'éléments.
+
+= render "/partials/example.haml", caption: "Menu déroulant avec un formulaire", code: dropdown_with_form do
+  :markdown
+    Un menu déroulant peut également contenir un formulaire ou tout autre contenu HTML.
+
+= render "/partials/example.haml", caption: "Menu déroulant avec des attributs personnalisés", code: dropdown_with_custom_attributes do
+  :markdown
+    Vous pouvez personnaliser les attributs HTML du bouton et du conteneur du menu déroulant.
+
+= render "/partials/related-info.haml", links: dsfr_component_doc_links("menu-deroulant", "dropdown")

--- a/guide/content/components/dropdown.haml
+++ b/guide/content/components/dropdown.haml
@@ -21,5 +21,3 @@ title: Menu déroulant - Dropdown
 = render "/partials/example.haml", caption: "Menu déroulant avec des attributs personnalisés", code: dropdown_with_custom_attributes do
   :markdown
     Vous pouvez personnaliser les attributs HTML du bouton et du conteneur du menu déroulant.
-
-= render "/partials/related-info.haml", links: dsfr_component_doc_links("menu-deroulant", "dropdown")

--- a/guide/content/components/dropdown.haml
+++ b/guide/content/components/dropdown.haml
@@ -4,7 +4,7 @@ title: Menu déroulant - Dropdown
 
 .fr-text-wrap
   :markdown
-    Le composant de menu déroulant (dropdown) permet d'afficher du contenu qui apparaît et disparaît lorsque l'utilisateur clique sur un bouton.
+    Le menu déroulant présente une liste d'actions ou de choix parmi lesquels un utilisateur peut sélectionner une ou plusieurs options.
 
 = render "/partials/example.haml", caption: "Menu déroulant simple", code: dropdown_simple do
   :markdown

--- a/guide/content/components/dropdown.haml
+++ b/guide/content/components/dropdown.haml
@@ -21,3 +21,5 @@ title: Menu déroulant - Dropdown
 = render "/partials/example.haml", caption: "Menu déroulant avec des attributs personnalisés", code: dropdown_with_custom_attributes do
   :markdown
     Vous pouvez personnaliser les attributs HTML du bouton et du conteneur du menu déroulant.
+
+= render('/partials/related-info.haml', links: dsfr_component_doc_links("menu-deroulant", "dropdown", beta: true))

--- a/guide/lib/examples/dropdown_helpers.rb
+++ b/guide/lib/examples/dropdown_helpers.rb
@@ -34,8 +34,8 @@ module Examples
     def dropdown_with_custom_attributes
       <<~DROPDOWN
         = dsfr_dropdown title: "Menu personnalisé",
-          html_attributes: { class: "fr-btn--secondary", "data-custom": "value" },
-          collapse_html_attributes: { class: "fr-menu", "data-collapse-custom": "value" } do
+          html_attributes: { class: "fr-btn--secondary fr-icon-filter-line", "data-custom": "value" },
+          collapse_html_attributes: { "data-controller": "foo" } do
           %ul.fr-menu__list
             %li
               %a.fr-nav__link{href: "#"} Option A

--- a/guide/lib/examples/dropdown_helpers.rb
+++ b/guide/lib/examples/dropdown_helpers.rb
@@ -1,0 +1,47 @@
+module Examples
+  module DropdownHelpers
+    def dropdown_simple
+      <<~DROPDOWN
+        = dsfr_dropdown title: "Cliquez-moi" do
+          %p Ce contenu apparaît lorsque vous cliquez sur le bouton.
+      DROPDOWN
+    end
+
+    def dropdown_with_list
+      <<~DROPDOWN
+        = dsfr_dropdown title: "Menu" do
+          %ul.fr-menu__list
+            %li
+              %a.fr-nav__link{href: "#"} Option 1
+            %li
+              %a.fr-nav__link{href: "#"} Option 2
+            %li
+              %a.fr-nav__link{href: "#"} Option 3
+      DROPDOWN
+    end
+
+    def dropdown_with_form
+      <<~DROPDOWN
+        = dsfr_dropdown title: "Recherche" do
+          %form
+            .fr-input-group
+              %label.fr-label{for: "search"} Rechercher
+              %input.fr-input{type: "text", id: "search", name: "search", placeholder: "Rechercher..."}
+              %button.fr-btn{type: "submit"} Rechercher
+      DROPDOWN
+    end
+
+    def dropdown_with_custom_attributes
+      <<~DROPDOWN
+        = dsfr_dropdown title: "Menu personnalisé",
+          html_attributes: { class: "fr-btn--secondary", "data-custom": "value" },
+          collapse_html_attributes: { class: "fr-menu", "data-collapse-custom": "value" } do
+          %ul.fr-menu__list
+            %li
+              %a.fr-nav__link{href: "#"} Option A
+            %li
+              %a.fr-nav__link{href: "#"} Option B
+      DROPDOWN
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -55,3 +55,4 @@ use_helper Examples::CalloutHelpers
 use_helper Examples::NoticeHelpers
 use_helper Examples::SearchHelpers
 use_helper Examples::ProconnectButtonHelpers
+use_helper Examples::DropdownHelpers

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -1,6 +1,7 @@
 module Helpers
   module ContentHelpers
     DSFR_COMPONENT_DOC_HREF = "https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants".freeze
+    DSFR_COMPONENT_BETA_DOC_HREF = "https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants-beta".freeze
     DSFR_COMPONENT_STORYBOOK_HREF = "https://storybook.systeme-de-design.gouv.fr".freeze
 
     def site_title
@@ -9,9 +10,9 @@ module Helpers
 
   private
 
-    def dsfr_component_doc_links(doc_id = nil, storybook_id = nil)
+    def dsfr_component_doc_links(doc_id = nil, storybook_id = nil, beta: false)
       {
-        "Voir #{@item[:title]} dans la documentation officielle" => "#{DSFR_COMPONENT_DOC_HREF}/#{doc_id}/",
+        "Voir #{@item[:title]} dans la documentation officielle" => "#{beta ? DSFR_COMPONENT_BETA_DOC_HREF : DSFR_COMPONENT_DOC_HREF}/#{doc_id}/",
         "Voir #{@item[:title]} sur le Storybook officiel" => "#{DSFR_COMPONENT_STORYBOOK_HREF}/?path=/docs/#{storybook_id}--docs"
       }
     end

--- a/spec/components/dsfr_component/dropdown_component_spec.rb
+++ b/spec/components/dsfr_component/dropdown_component_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe(DsfrComponent::DropdownComponent, type: :component) do
+  subject(:rendered_content) { render_inline(component).to_s }
+
+  let(:title) { "Services" }
+  let(:kwargs) { { title: title } }
+  let(:component) { described_class.new(**kwargs).with_content("Content") }
+  let(:component_css_class) { "fr-btn" }
+
+  context "without parameters" do
+    it "renders the dropdown" do
+      expect(rendered_content).to have_tag("button", with: {
+                                             class: "fr-btn",
+                                             "aria-expanded": "false",
+                                             "aria-controls": component.dropdown_id
+                                           }, text: title)
+    end
+
+    it "renders the dropdown collapse" do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-collapse" }, text: "Content")
+    end
+  end
+
+  context "with custom html attributes for button" do
+    let(:custom_attributes) { { "data-custom": "value", "aria-label": "Dropdown menu" } }
+    let(:kwargs) { { title: title, html_attributes: custom_attributes } }
+
+    it "renders the button with custom attributes" do
+      expect(rendered_content).to have_tag("button", with: custom_attributes.merge(class: "fr-btn"))
+    end
+  end
+
+  context "with custom html attributes for collapse div" do
+    let(:collapse_attributes) { { class: "fr-collapse fr-menu", "data-collapse": "true" } }
+    let(:kwargs) { { title: title, collapse_html_attributes: collapse_attributes } }
+
+    it "renders the collapse div with custom attributes" do
+      expect(rendered_content).to have_tag("div", with: { class: "fr-collapse fr-menu", "data-collapse": "true" })
+    end
+  end
+
+  it_behaves_like "a component that accepts custom HTML attributes"
+end

--- a/spec/components/dsfr_component/header_component_spec.rb
+++ b/spec/components/dsfr_component/header_component_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe(DsfrComponent::HeaderComponent, type: :component) do
         end
         with_tag "div", with: { class: "fr-header__menu" } do
           with_tag "nav", with: { class: "fr-nav" } do
-            with_tag "button", with: { class: "fr-btn fr-nav__btn", "aria-controls": "menu-aide" }, text: "Aide"
+            with_tag "button", with: { class: "fr-nav__btn", "aria-controls": "menu-aide" }, text: "Aide"
             with_tag :div, with: { class: "fr-collapse fr-menu", id: "menu-aide" } do
               with_tag :ul, with: { class: "fr-menu__list" } do
                 with_tag :li do
@@ -152,7 +152,7 @@ RSpec.describe(DsfrComponent::HeaderComponent, type: :component) do
                 end
               end
             end
-            with_tag "button", with: { class: "fr-btn fr-nav__btn", "aria-controls": "menu-environnement" }, text: "Environnement"
+            with_tag "button", with: { class: "fr-nav__btn", "aria-controls": "menu-environnement" }, text: "Environnement"
             with_tag :div, with: { class: "fr-collapse fr-menu", id: "menu-environnement" } do
               with_tag :ul, with: { class: "fr-menu__list" } do
                 with_tag :li do

--- a/spec/components/dsfr_component/header_component_spec.rb
+++ b/spec/components/dsfr_component/header_component_spec.rb
@@ -141,15 +141,27 @@ RSpec.describe(DsfrComponent::HeaderComponent, type: :component) do
         end
         with_tag "div", with: { class: "fr-header__menu" } do
           with_tag "nav", with: { class: "fr-nav" } do
-            with_tag "button", with: { class: "fr-nav__btn", "aria-controls": "menu-aide" }, text: "Aide"
-            with_tag :div, with: { class: "fr-menu", id: "menu-aide" } do
-              with_tag :a, with: { class: "fr-nav__link", href: "#comment-ca-marche" }, text: "Comment ça marche"
-              with_tag :a, with: { class: "fr-nav__link", href: "#contact" }, text: "Contact"
+            with_tag "button", with: { class: "fr-btn fr-nav__btn", "aria-controls": "menu-aide" }, text: "Aide"
+            with_tag :div, with: { class: ["fr-collapse", "fr-menu"], id: "menu-aide" } do
+              with_tag :ul, with: { class: "fr-menu__list" } do
+                with_tag :li do
+                  with_tag :a, with: { class: "fr-nav__link", href: "#comment-ca-marche" }, text: "Comment ça marche"
+                end
+                with_tag :li do
+                  with_tag :a, with: { class: "fr-nav__link", href: "#contact" }, text: "Contact"
+                end
+              end
             end
-            with_tag "button", with: { class: "fr-nav__btn", "aria-controls": "menu-environnement" }, text: "Environnement"
-            with_tag :div, with: { class: "fr-menu", id: "menu-environnement" } do
-              with_tag :a, with: { class: "fr-nav__link", href: "#beta-gouv" }, text: "Beta Gouv"
-              with_tag :a, with: { class: "fr-nav__link", href: "#dsfr" }, text: "DSFR"
+            with_tag "button", with: { class: "fr-btn fr-nav__btn", "aria-controls": "menu-environnement" }, text: "Environnement"
+            with_tag :div, with: { class: ["fr-collapse", "fr-menu"], id: "menu-environnement" } do
+              with_tag :ul, with: { class: "fr-menu__list" } do
+                with_tag :li do
+                  with_tag :a, with: { class: "fr-nav__link", href: "#beta-gouv" }, text: "Beta Gouv"
+                end
+                with_tag :li do
+                  with_tag :a, with: { class: "fr-nav__link", href: "#dsfr" }, text: "DSFR"
+                end
+              end
             end
           end
           without_tag "div", with: { class: "fr-header__search" }

--- a/spec/components/dsfr_component/header_component_spec.rb
+++ b/spec/components/dsfr_component/header_component_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe(DsfrComponent::HeaderComponent, type: :component) do
         with_tag "div", with: { class: "fr-header__menu" } do
           with_tag "nav", with: { class: "fr-nav" } do
             with_tag "button", with: { class: "fr-btn fr-nav__btn", "aria-controls": "menu-aide" }, text: "Aide"
-            with_tag :div, with: { class: ["fr-collapse", "fr-menu"], id: "menu-aide" } do
+            with_tag :div, with: { class: "fr-collapse fr-menu", id: "menu-aide" } do
               with_tag :ul, with: { class: "fr-menu__list" } do
                 with_tag :li do
                   with_tag :a, with: { class: "fr-nav__link", href: "#comment-ca-marche" }, text: "Comment ça marche"
@@ -153,7 +153,7 @@ RSpec.describe(DsfrComponent::HeaderComponent, type: :component) do
               end
             end
             with_tag "button", with: { class: "fr-btn fr-nav__btn", "aria-controls": "menu-environnement" }, text: "Environnement"
-            with_tag :div, with: { class: ["fr-collapse", "fr-menu"], id: "menu-environnement" } do
+            with_tag :div, with: { class: "fr-collapse fr-menu", id: "menu-environnement" } do
               with_tag :ul, with: { class: "fr-menu__list" } do
                 with_tag :li do
                   with_tag :a, with: { class: "fr-nav__link", href: "#beta-gouv" }, text: "Beta Gouv"


### PR DESCRIPTION
- [x] Extraction du mécanisme de dropdown
- [x] Ajout de tests et de documentation
- [x] Ajout d'un helper
- [x] Utilisation du nouveau composant dans les liens d'en-tête

Le mécanisme de dropdown est utilisé à plusieurs endroits, notamment dans les tableaux, quand on veut filtrer selon une ou plusieurs valeurs. Ce n'est pas montré dans la [documentation](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/tableau), mais c'est présenté dans [Figma](https://www.figma.com/community/file/1042832984468443942/dsfr-composants-v1-13-1) (page Tableau, un des derniers panneaux sur la droite).

![tableau avec filtre dans une cellule d'en-tête](https://github.com/user-attachments/assets/75df9265-4c25-4350-b149-0690ec0c193a)
