### PR TITLE
fix: Handle nested hashes in search component hidden fields

### DIFF
--- a/app/components/dsfr_component/search_component.html.erb
+++ b/app/components/dsfr_component/search_component.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(url: url, method: :get, **html_attributes) do |form| %>
-  <% hidden_fields.each do |name, value| %>
-  <%= form.hidden_field(name, value: value) %>
+  <% flatten_hidden_fields(hidden_fields).each do |name, value| %>
+    <%= form.hidden_field(name, value: value) %>
   <% end %>
   <%= form.label(name, label_text, for: id, class: 'fr-label') %>
   <%= form.search_field(name, id: id, placeholder: button_text, value: value, class: 'fr-input') %>

--- a/app/components/dsfr_component/search_component.rb
+++ b/app/components/dsfr_component/search_component.rb
@@ -29,6 +29,19 @@ module DsfrComponent
 
     attr_reader :url, :size, :name, :label_text, :button_text, :hidden_fields, :html_attributes
 
+    def flatten_hidden_fields(fields, prefix = nil)
+      flattened = []
+      fields.each do |key, value|
+        field_name = prefix ? "#{prefix}[#{key}]" : key.to_s
+        if value.is_a?(Hash)
+          flattened.concat(flatten_hidden_fields(value, field_name))
+        else
+          flattened << [field_name, value]
+        end
+      end
+      flattened
+    end
+
     def id
       "#{name}_#{object_id}"
     end

--- a/spec/components/dsfr_component/search_component_spec.rb
+++ b/spec/components/dsfr_component/search_component_spec.rb
@@ -49,4 +49,29 @@ RSpec.describe(DsfrComponent::SearchComponent, type: :component) do
       end
     end
   end
+
+  describe "nested hidden fields" do
+    let(:args) { { url: url, hidden_fields: { filter: { category: "books", status: "available" }, simple: "value" } } }
+
+    it "renders nested hash values as nested field names" do
+      expect(rendered_content).to have_tag(:form) do
+        with_tag(:input, with: { type: :hidden, name: "filter[category]", value: "books" })
+        with_tag(:input, with: { type: :hidden, name: "filter[status]", value: "available" })
+        with_tag(:input, with: { type: :hidden, name: "simple", value: "value" })
+      end
+    end
+  end
+
+  describe "deeply nested hidden fields" do
+    let(:args) { { url: url, hidden_fields: { filter: { options: { category: "books", subcategory: "fiction" }, active: true }, user: { preferences: { theme: "dark" } } } } }
+
+    it "renders deeply nested hash values with correct field names" do
+      expect(rendered_content).to have_tag(:form) do
+        with_tag(:input, with: { type: :hidden, name: "filter[options][category]", value: "books" })
+        with_tag(:input, with: { type: :hidden, name: "filter[options][subcategory]", value: "fiction" })
+        with_tag(:input, with: { type: :hidden, name: "filter[active]", value: "true" })
+        with_tag(:input, with: { type: :hidden, name: "user[preferences][theme]", value: "dark" })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Si on essaie de stocker un paramètre au format hash dans un champ hidden du formulaire de recherche, il est stocké en tant que `name="clé" value="{\"sous-clé\" => \"valeur\"}"`, ce qui fait planter la lecture des paramètres dans le reste de l'application.
Cette PR propose de stocker `name="clé[sous-clé]" value="valeur"`, de manière récursive (il peut donc y avoir des sous-sous-clés, etc).