### PR TITLE
Ajout des badges sur le composant tuile

### DIFF
--- a/app/components/dsfr_component/tile_component.html.erb
+++ b/app/components/dsfr_component/tile_component.html.erb
@@ -1,6 +1,13 @@
 <%= tag.div(**html_attributes) do %>
   <div class="fr-tile__body">
     <div class="fr-tile__content">
+      <% if badges.any? %>
+        <div class="fr-tile__start">
+          <% badges.each do |badge| %>
+            <%= badge %>
+          <% end %>
+        </div>
+      <% end %>
       <%= title_tag(class: "fr-tile__title") do %>
         <a class="fr-tile__link" href="<%= url %>">
           <%= title %>

--- a/app/components/dsfr_component/tile_component.rb
+++ b/app/components/dsfr_component/tile_component.rb
@@ -1,5 +1,7 @@
 module DsfrComponent
   class TileComponent < DsfrComponent::Base
+    renders_many :badges, "DsfrComponent::BadgeComponent"
+
     # @param title [String] title (required)
     # @param url [String] url (required)
     # @param image_src [String] chemin vers l'image (optional)
@@ -19,6 +21,10 @@ module DsfrComponent
       raise ArgumentError if HEADING_LEVELS.exclude?(heading_level)
 
       super(html_attributes: html_attributes)
+    end
+
+    def before_render
+      raise ArgumentError, "TileComponent accepte au maximum 4 badges (#{badges.size} fournis)" if badges.size > 4
     end
 
   private

--- a/guide/content/components/tile.haml
+++ b/guide/content/components/tile.haml
@@ -29,4 +29,6 @@ title: Tuile - Tile
 
     Le niveau par défaut est `4`, vous pouvez l’augmenter ou le baisser selon votre contexte.
 
+= render('/partials/example.haml', caption: "Tuile avec badges", code: tile_with_badges)
+
 = render('/partials/related-info.haml', links: dsfr_component_doc_links("tuile"))

--- a/guide/lib/examples/tile_helpers.rb
+++ b/guide/lib/examples/tile_helpers.rb
@@ -60,5 +60,17 @@ module Examples
                     html_attributes: {style: "max-width: 20rem;"})
       RAW
     end
+
+    def tile_with_badges
+      <<~RAW
+        = dsfr_tile(title: "Orgue de Fontainebleau",
+                    url: "#",
+                    image_src: "/assets/images/orgue.jpg",
+                    description: "Magistral instrument de musique",
+                    html_attributes: {style: "max-width: 20rem;"}) do |tile|
+          - tile.with_badge(status: :new) { "Nouveau" }
+          - tile.with_badge(status: :info) { "Patrimoine" }
+      RAW
+    end
   end
 end

--- a/spec/components/dsfr_component/tile_component_spec.rb
+++ b/spec/components/dsfr_component/tile_component_spec.rb
@@ -61,6 +61,46 @@ RSpec.describe(DsfrComponent::TileComponent, type: :component) do
     end
   end
 
+  context 'with badges' do
+    subject! do
+      render_inline(described_class.new(url: "/path", title: 'Titre')) do |tile|
+        tile.with_badge(status: :new) { "Nouveau" }
+        tile.with_badge(status: :info) { "Info" }
+      end
+    end
+
+    specify 'renders correctly' do
+      expect(rendered_content).to have_tag('div', with: { class: "fr-tile fr-enlarge-link" }) do
+        with_tag('div', with: { class: 'fr-tile__content' }) do
+          with_tag('div', with: { class: 'fr-tile__start' }) do
+            with_tag('div', with: { class: 'fr-badge fr-badge--new' }, text: /Nouveau/)
+            with_tag('div', with: { class: 'fr-badge fr-badge--info' }, text: /Info/)
+          end
+        end
+      end
+    end
+  end
+
+  context 'with more than 4 badges' do
+    let(:args) { { url: "/path", title: 'Titre' } }
+
+    specify 'raises an ArgumentError' do
+      expect do
+        render_inline(described_class.new(url: "/path", title: 'Titre')) do |tile|
+          5.times { tile.with_badge(status: :info) { "Badge" } }
+        end
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'without badges' do
+    let(:args) { { url: "/path", title: 'Titre' } }
+
+    specify 'does not render fr-tile__start' do
+      expect(rendered_content).not_to have_tag('div', with: { class: 'fr-tile__start' })
+    end
+  end
+
   context 'with specific title_level' do
     let(:args) { { url: "/path", title: 'Titre', heading_level: 2 } }
 


### PR DESCRIPTION
Dans le DSFR, on peut ajouter des badges sur les tuiles DSFR.
Je propose donc d’ajouter cette fonctionnalité

<img width="354" height="342" alt="image" src="https://github.com/user-attachments/assets/dc611fce-d7b8-41b5-8b26-a7290b03f4fb" />
