### PR TITLE
Fixer la version de Rubocop

### DIFF
--- a/dsfr-view-components.gemspec
+++ b/dsfr-view-components.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.9"
-  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop", "~> 1.90"
   spec.add_development_dependency "simplecov", "~> 0.20"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "yard"

--- a/spec/components/dsfr_component/search_component_spec.rb
+++ b/spec/components/dsfr_component/search_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe(DsfrComponent::SearchComponent, type: :component) do
   end
 
   describe "size option" do
-    # rubocop:disable RSpec/MultipleExpectations
+    # rubocop:disable-next RSpec/MultipleExpectations
     %i[sm md lg].each do |size|
       context "when size is :#{size}" do
         let(:args) { { url: url, size: size } }
@@ -33,7 +33,6 @@ RSpec.describe(DsfrComponent::SearchComponent, type: :component) do
         end
       end
     end
-    # rubocop:enable RSpec/MultipleExpectations
   end
 
   describe "other options" do


### PR DESCRIPTION
La CI s’est mise a cassé ici : https://github.com/betagouv/dsfr-view-components/pull/269 suite à une mise à jour de Rubocop

Je propose donc : 
- De fixer la version de Rubocop pour éviter que ça se mette a casser lors d’une prochaine mise à jour
- D’appliquer cette nouvelle règle qui a provoqué l’erreur